### PR TITLE
Flash CAN_ID and more

### DIFF
--- a/sw/Drivers/Imu/Inc/asm330lhh.h
+++ b/sw/Drivers/Imu/Inc/asm330lhh.h
@@ -11,6 +11,8 @@
 #ifndef ASM330LHH_H
 #define ASM330LHH_H
 
+#include "imu.h"
+
 ImuStatus_E setup_imu_asm330lhh();
 
 ImuStatus_E poll_imu_asm330lhh(ImuData_S *imu_data);

--- a/sw/Drivers/Imu/Src/asm330lhh.c
+++ b/sw/Drivers/Imu/Src/asm330lhh.c
@@ -15,7 +15,6 @@
 
 #include "asm330lhh_reg.h"
 #include "gpio.h"
-#include "imu.h"
 #include "spi.h"
 
 ////////

--- a/sw/Modules/Comms/Src/can_interface.c
+++ b/sw/Modules/Comms/Src/can_interface.c
@@ -9,9 +9,10 @@
 
 #include "string.h"
 
-/* ATTENTION: NODE ID needs to be hard-coded differently between boards! */
-/* TODO: Configurable NODE ID through build system */
-#define NODE_ID 0x20
+/* Configurable NODE_ID through build system, default 20 */
+#ifndef NODE_ID
+#define NODE_ID 20
+#endif
 
 /* the master hal can handler*/
 extern CAN_HandleTypeDef hcan;
@@ -46,7 +47,7 @@ void setup_comms(void) {
 #endif
 
   /* Hardcodinig a node id for this can node */
-  canard.node_id = NODE_ID;
+  canardSetLocalNodeID(&canard, NODE_ID);
 
   /* set a static variable to the current tick */
   next_1hz_service_at = HAL_GetTick();

--- a/sw/Modules/Comms/Src/can_sensors.c
+++ b/sw/Modules/Comms/Src/can_sensors.c
@@ -76,7 +76,7 @@ void can_receive_ImuData(CanardInstance *ins, CanardRxTransfer *transfer) {
   /* If the imu reception handler is defined elsewhere, then run the handler
    * function */
   if (imu_reception_f_ptr != NULL) {
-    uint8_t can_id = 10;  // fake data
+	uint8_t can_id = transfer->source_node_id;
     imu_reception_f_ptr(&rawIMU, can_id);
   }
 
@@ -159,7 +159,7 @@ void can_receive_GpsData(CanardInstance *ins, CanardRxTransfer *transfer) {
   /* If the imu reception handler is defined elsewhere, then run the handler
    * function */
   if (gps_reception_f_ptr != NULL) {
-    uint8_t can_id = 10;  // fake data
+    uint8_t can_id = transfer->source_node_id;
     gps_reception_f_ptr(&gps_data, can_id);
   }
 

--- a/sw/Modules/Fusion/Src/sensor_board.c
+++ b/sw/Modules/Fusion/Src/sensor_board.c
@@ -24,9 +24,11 @@
 
 #define NUM_IMUS 1
 #define NUM_GNSS 1
-//  TODO: intruduce this macro in build system instead, plus making this
-//  configurable in build
-// #define IMU_ID   10
+
+/* this delay serves for staggering the CAN bus TX timing, default 0 */
+#ifndef BOARD_INIT_DELAY_MS
+#define BOARD_INIT_DELAY_MS 0
+#endif
 
 extern UART_HandleTypeDef huart1;
 
@@ -59,6 +61,8 @@ static void poll_peripherals() {
 }
 
 void run_sensor_board() {
+  HAL_Delay(BOARD_INIT_DELAY_MS);
+
   (void)setup_peripherals();
   setup_comms();
 

--- a/sw/sensor_board/sensor_board_rev0/CMakeLists.txt
+++ b/sw/sensor_board/sensor_board_rev0/CMakeLists.txt
@@ -14,6 +14,14 @@ set(PROJECT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # Disabling the can reception handle for now... for the sake of binary size
 add_definitions(-DSENSOR_BOARD_CAN_RECEPTION_DISABLE)
 
+# Provide default value
+option(NODE_ID "Board's CAN Node ID" "20")
+option(BOARD_INIT_DELAY_MS "Board initialization delay in ms" "0")
+
+# Pass it as a compile definition
+add_compile_definitions(NODE_ID=0x${NODE_ID})
+add_compile_definitions(BOARD_INIT_DELAY_MS=${BOARD_INIT_DELAY_MS})
+
 ### Includes ###
 include_directories(
   # Default STM32 HAL Libraries

--- a/sw/sensor_board/sensor_board_rev0/build.bash
+++ b/sw/sensor_board/sensor_board_rev0/build.bash
@@ -9,34 +9,62 @@ TEST=false
 FLASH=false
 BUILD_TYPE="Debug"
 GENERATOR="Unix Makefiles"
+NODE_ID="20"
+BOARD_INIT_DELAY_MS="0"
 
-while getopts "c,t,h,f,r" opt; do
-    case $opt in
-        c)
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c)
             CLEAN=true
-        ;;
-        t)
+            shift
+            ;;
+        -t)
             TEST=true
-        ;;
-        f)
+            shift
+            ;;
+        -f)
             FLASH=true
-        ;;
-        r)
+            shift
+            ;;
+        -r)
             BUILD_TYPE="Release"
-        ;;
-        h|\?)
+            shift
+            ;;
+        -id)
+            if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+                NODE_ID="$2"
+                shift 2
+            else
+                echo "Error: -id must be followed by a numeric value"
+                exit 1
+            fi
+            ;;
+        -delay)
+            if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+                BOARD_INIT_DELAY_MS="$2"
+                shift 2
+            else
+                echo "Error: -delay must be followed by a numeric value"
+                exit 1
+            fi
+            ;;
+        -h|--help|*)
             printf "%s\n" "Usage: $0 [OPTIONS]"\
                 "Script to build the sensor_board_rev0 project"\
                 "    -f                 - flashes the Safety after building"\
                 "    -c                 - removes previous build files before building"\
                 "    -h                 - outputs this message"\
                 "    -t                 - runs tests after building if build is successful"\
-                "    -r                 - Sets the build type to release"
+                "    -r                 - sets the build type to Release"\
+                "    -id <value>        - sets NODE_ID (e.g., -id 20)"\
+                "    -delay <value>     - sets BOARD_INIT_DELAY_MS (e.g., -delay 100)"
             exit 1
-        ;;
+            ;;
     esac
 done
 
+# Determine generator
 if command -v ninja >/dev/null 2>&1; then
     GENERATOR="Ninja"
 elif command -v make >/dev/null 2>&1; then
@@ -52,7 +80,6 @@ die() {
     exit $1
 }
 
-# Set up exit condition
 trap 'die $? $LINENO' ERR
 
 BUILD_DIR="build"
@@ -62,34 +89,45 @@ if [[ $CLEAN == true ]]; then
     cmake -E remove_directory $BUILD_DIR
 fi
 
-# Prebuild info display
-echo "Building ..."
-# if [[ $# > 0 ]]; then
-#     echo "with cmake parameters: $@"
-# fi
+echo "Building..."
 
-# Build commands
-cmake -E make_directory $BUILD_DIR
-cmake -E chdir $BUILD_DIR \
-  cmake \
-    -G "${GENERATOR}" \
-    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-    -DCMAKE_TOOLCHAIN_FILE="sensor_board_rev0.cmake" \
-    -Wdev\
-    -Wdeprecated\
-    ../
+# Construct cmake command
+CMAKE_CMD=(
+    cmake -E chdir "$BUILD_DIR"
+    cmake
+    -G "$GENERATOR"
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+    -DCMAKE_TOOLCHAIN_FILE="sensor_board_rev0.cmake"
+    -Wdev
+    -Wdeprecated
+)
 
-cmake --build $BUILD_DIR
-
-if [[ $TEST == true ]] ; then
-    cmake --build $BUILD_DIR --target test
+# Include NODE_ID if specified
+if [[ -n "$NODE_ID" ]]; then
+    echo "Using NODE_ID=$NODE_ID"
+    CMAKE_CMD+=("-DNODE_ID=$NODE_ID")
 fi
 
-if [[ $FLASH == true ]] ; then
-    cmake --build $BUILD_DIR --target install
+if [[ -n "$BOARD_INIT_DELAY_MS" ]]; then
+    echo "Using BOARD_INIT_DELAY_MS=$BOARD_INIT_DELAY_MS"
+    CMAKE_CMD+=("-DBOARD_INIT_DELAY_MS=$BOARD_INIT_DELAY_MS")
 fi
 
-# Final status display
+CMAKE_CMD+=("../")
+
+# Build steps
+cmake -E make_directory "$BUILD_DIR"
+"${CMAKE_CMD[@]}"
+cmake --build "$BUILD_DIR"
+
+if [[ $TEST == true ]]; then
+    cmake --build "$BUILD_DIR" --target test
+fi
+
+if [[ $FLASH == true ]]; then
+    cmake --build "$BUILD_DIR" --target install
+fi
+
 echo ""
 echo "Build SUCCESS!"
 exit 0

--- a/sw/sensor_board/sensor_bridge_rev0/CMakeLists.txt
+++ b/sw/sensor_board/sensor_bridge_rev0/CMakeLists.txt
@@ -11,6 +11,12 @@ set(PROJECT_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 # Set project source dir to "sensor_bridge_rev0"
 set(PROJECT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+# Provide default value for macros
+option(NODE_ID "Board's CAN Node ID" "20")
+
+# Pass it as a compile definition
+add_compile_definitions(NODE_ID=0x${NODE_ID})
+
 ### Includes ###
 include_directories(
   # Default STM32 HAL Libraries

--- a/sw/sensor_board/sensor_bridge_rev0/build.bash
+++ b/sw/sensor_board/sensor_bridge_rev0/build.bash
@@ -9,34 +9,51 @@ TEST=false
 FLASH=false
 BUILD_TYPE="Debug"
 GENERATOR="Unix Makefiles"
+NODE_ID="20"
 
-while getopts "c,t,h,f,r" opt; do
-    case $opt in
-        c)
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c)
             CLEAN=true
-        ;;
-        t)
+            shift
+            ;;
+        -t)
             TEST=true
-        ;;
-        f)
+            shift
+            ;;
+        -f)
             FLASH=true
-        ;;
-        r)
+            shift
+            ;;
+        -r)
             BUILD_TYPE="Release"
-        ;;
-        h|\?)
+            shift
+            ;;
+        -id)
+            if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+                NODE_ID="$2"
+                shift 2
+            else
+                echo "Error: -id must be followed by a numeric value"
+                exit 1
+            fi
+            ;;
+        -h|--help|*)
             printf "%s\n" "Usage: $0 [OPTIONS]"\
-                "Script to build the sensor_board_rev0 project"\
+                "Script to build the sensor_bridge_rev0 project"\
                 "    -f                 - flashes the Safety after building"\
                 "    -c                 - removes previous build files before building"\
                 "    -h                 - outputs this message"\
                 "    -t                 - runs tests after building if build is successful"\
-                "    -r                 - Sets the build type to release"
+                "    -r                 - sets the build type to Release"\
+                "    -id <value>        - sets NODE_ID (e.g., -id 20)"\
             exit 1
-        ;;
+            ;;
     esac
 done
 
+# Determine generator
 if command -v ninja >/dev/null 2>&1; then
     GENERATOR="Ninja"
 elif command -v make >/dev/null 2>&1; then
@@ -52,7 +69,6 @@ die() {
     exit $1
 }
 
-# Set up exit condition
 trap 'die $? $LINENO' ERR
 
 BUILD_DIR="build"
@@ -62,34 +78,40 @@ if [[ $CLEAN == true ]]; then
     cmake -E remove_directory $BUILD_DIR
 fi
 
-# Prebuild info display
-echo "Building ..."
-# if [[ $# > 0 ]]; then
-#     echo "with cmake parameters: $@"
-# fi
+echo "Building..."
 
-# Build commands
-cmake -E make_directory $BUILD_DIR
-cmake -E chdir $BUILD_DIR \
-  cmake \
-    -G "${GENERATOR}" \
-    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-    -DCMAKE_TOOLCHAIN_FILE="sensor_bridge_rev0.cmake" \
-    -Wdev\
-    -Wdeprecated\
-    ../
+# Construct cmake command
+CMAKE_CMD=(
+    cmake -E chdir "$BUILD_DIR"
+    cmake
+    -G "$GENERATOR"
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+    -DCMAKE_TOOLCHAIN_FILE="sensor_bridge_rev0.cmake"
+    -Wdev
+    -Wdeprecated
+)
 
-cmake --build $BUILD_DIR
-
-if [[ $TEST == true ]] ; then
-    cmake --build $BUILD_DIR --target test
+# Include NODE_ID if specified
+if [[ -n "$NODE_ID" ]]; then
+    echo "Using NODE_ID=$NODE_ID"
+    CMAKE_CMD+=("-DNODE_ID=$NODE_ID")
 fi
 
-if [[ $FLASH == true ]] ; then
-    cmake --build $BUILD_DIR --target install
+CMAKE_CMD+=("../")
+
+# Build steps
+cmake -E make_directory "$BUILD_DIR"
+"${CMAKE_CMD[@]}"
+cmake --build "$BUILD_DIR"
+
+if [[ $TEST == true ]]; then
+    cmake --build "$BUILD_DIR" --target test
 fi
 
-# Final status display
+if [[ $FLASH == true ]]; then
+    cmake --build "$BUILD_DIR" --target install
+fi
+
 echo ""
 echo "Build SUCCESS!"
 exit 0


### PR DESCRIPTION
# Summary
- Fixed a compilation issue from the previous format PR, turns out to be our issue, but somehow the build system was okay with that.
- Allowing the user to pass NODE_ID and BOARD_INIT_DELAY in build time.
- Removed some can id hardcoding during the work session last night.