### PR TITLE
Port nmea-parser to work without SERDE, add basic GPS message parsing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ee/sensor_board/vehicle_daq_pcb_rev1"]
 	path = ee/sensor_board/vehicle_daq_pcb_rev1
 	url = https://github.com/HardyYu/vehicle_daq_pcb_rev1
+[submodule "sw/Drivers/nmea-parser"]
+	path = sw/Drivers/nmea-parser
+	url = https://github.com/antholuo/nmea-parser.git

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
@@ -3,6 +3,30 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "allocator-api2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +59,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +87,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "critical-section"
@@ -398,6 +443,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "esp-alloc"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e95f1de57ce5a6600368f3d3c931b0dfe00501661e96f5ab83bc5cdee031784"
+dependencies = [
+ "allocator-api2 0.3.1",
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "enumset",
+ "linked_list_allocator",
+]
+
+[[package]]
 name = "esp-bootloader-esp-idf"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +787,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2 0.2.21",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -755,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -811,6 +886,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked_list_allocator"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +925,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "nmea-parser"
+version = "0.12.0-dev"
+dependencies = [
+ "bitvec",
+ "chrono",
+ "hashbrown 0.14.5",
+ "log",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +952,12 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "paste"
@@ -920,6 +1018,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
@@ -1018,12 +1122,14 @@ dependencies = [
  "embassy-executor",
  "embassy-time",
  "embedded-hal 1.0.0",
+ "esp-alloc",
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-hal-smartled2",
  "esp-println",
  "esp-rtos",
  "log",
+ "nmea-parser",
  "smart-leds",
 ]
 
@@ -1148,6 +1254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1374,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xtensa-lx"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1407,26 @@ name = "xtensa-lx-rt-proc-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "embedded-io-async 0.6.1",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ dependencies = [
  "embedded-io-async 0.6.1",
  "futures-core",
  "futures-sink",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -812,6 +812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1138,7 @@ dependencies = [
  "esp-hal-smartled2",
  "esp-println",
  "esp-rtos",
+ "heapless 0.9.2",
  "log",
  "nmea-parser",
  "smart-leds",

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -26,6 +26,7 @@ embassy-executor = "0.9.1"
 embassy-time = "0.5.0"
 nmea-parser = {path="../../Drivers/nmea-parser/", default-features=false, features = []}
 esp-alloc = "0.8.0"
+heapless = "0.9.2"
 
 [profile.dev]
 # Rust debug is too slow.

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -24,6 +24,7 @@ smart-leds = "0.4"
 esp-rtos = { version = "0.2.0", features = ["embassy", "esp32c6"] }
 embassy-executor = "0.9.1"
 embassy-time = "0.5.0"
+# nmea-parser = {version = "0.11.0", default-features = false}
 
 
 [profile.dev]

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -24,8 +24,8 @@ smart-leds = "0.4"
 esp-rtos = { version = "0.2.0", features = ["embassy", "esp32c6"] }
 embassy-executor = "0.9.1"
 embassy-time = "0.5.0"
-# nmea-parser = {version = "0.11.0", default-features = false}
-
+nmea-parser = {path="../../Drivers/nmea-parser/", default-features=false, features = []}
+esp-alloc = "0.8.0"
 
 [profile.dev]
 # Rust debug is too slow.
@@ -40,3 +40,6 @@ incremental      = false
 lto              = 'fat'
 opt-level        = 's'
 overflow-checks  = false
+
+[patch.crates-io]
+# nmea-parser = { git="https://github.com/mrdxxm/nmea-parser.git", branch="no_std"}

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -13,11 +13,11 @@ use crate::hmi::start_hmi;
 pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mut board: B) {
     info!("app is starting execution now");
 
-    let mut user_led = board.take_user_led();
+    let user_led = board.take_user_led();
     trace!("User Led initialized!");
-    let mut neopixel = board.take_neopixel();
+    let neopixel = board.take_neopixel();
     trace!("NeoPixel initialized!");
-    let mut gps2_uart = board.take_gps2_uart();
+    let gps2_uart = board.take_gps2_uart();
     trace!("Gps2_Uart initialized!");
 
     spawner.spawn(start_hmi_task(neopixel)).unwrap();
@@ -29,7 +29,7 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
 }
 
 #[embassy_executor::task]
-async fn start_hmi_task(mut neopixel: neopixel::NeoPixel<'static>) {
+async fn start_hmi_task(neopixel: neopixel::NeoPixel<'static>) {
     // Task configuration
     let neopixel_brightness: u8 = 15;
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -5,6 +5,7 @@
 use log::{debug, error, info, trace, warn};
 
 use crate::BoardPeripherals;
+use crate::gps::start_gps;
 use crate::hmi::neopixel;
 use crate::hmi::start_hmi;
 
@@ -15,8 +16,11 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
     trace!("User Led initialized!");
     let mut neopixel = board.take_neopixel();
     trace!("NeoPixel initialized!");
+    let mut gps2_uart = board.take_gps2_uart();
+    trace!("Gps2_Uart initialized!");
 
     spawner.spawn(start_hmi_task(neopixel)).unwrap();
+    spawner.spawn(start_gps_task(gps2_uart)).unwrap();
 
     loop {
         embassy_time::Timer::after_secs(1).await
@@ -29,4 +33,9 @@ async fn start_hmi_task(mut neopixel: neopixel::NeoPixel<'static>) {
     let neopixel_brightness: u8 = 15;
 
     start_hmi(neopixel, neopixel_brightness).await;
+}
+
+#[embassy_executor::task]
+async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Async>) {
+    start_gps(gps2_uart).await;
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -5,6 +5,7 @@
 use log::{debug, error, info, trace, warn};
 
 use crate::BoardPeripherals;
+use crate::gps::init_gps;
 use crate::gps::start_gps;
 use crate::hmi::neopixel;
 use crate::hmi::start_hmi;
@@ -37,5 +38,6 @@ async fn start_hmi_task(mut neopixel: neopixel::NeoPixel<'static>) {
 
 #[embassy_executor::task]
 async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Async>) {
+    gps2_uart = init_gps(gps2_uart).await;
     start_gps(gps2_uart).await;
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -20,6 +20,7 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
 pub struct DevkitC {
     pub user_led: Option<esp_hal::gpio::Output<'static>>,
     pub neopixel: Option<neopixel::NeoPixel<'static>>,
+    pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Async>>,
 }
 
 impl DevkitC {
@@ -42,10 +43,19 @@ impl DevkitC {
             esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80)).unwrap();
         let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO8);
 
+        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(9600);
+        info!("baudrate for gps2_uart_set");
+        let gps2_uart = esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
+            .unwrap()
+            .with_rx(peripherals.GPIO23)
+            .with_tx(peripherals.GPIO22)
+            .into_async();
+
         debug!(">>> devkitC returned things correctly");
         Self {
             user_led: Some(user_led),
             neopixel: Some(neopixel),
+            gps2_uart: Some(gps2_uart),
         }
     }
 }
@@ -59,6 +69,11 @@ impl BoardPeripherals for DevkitC {
     fn take_neopixel(&mut self) -> neopixel::NeoPixel<'static> {
         trace!("neopixel take called");
         self.neopixel.take().expect("NeoPixel already taken")
+    }
+
+    fn take_gps2_uart(&mut self) -> esp_hal::uart::Uart<'static, esp_hal::Async> {
+        trace!("gps2_uart take called");
+        self.gps2_uart.take().expect("gps2_uart already taken")
     }
 }
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -12,9 +12,25 @@ use log::{debug, error, info, trace, warn};
 
 use sensor_board_rev1_test::{BoardPeripherals, app::app_run, hmi::neopixel};
 
+use esp_alloc as _;
+
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {}
+}
+
+fn init_heap() {
+    const HEAP_SIZE: usize = 32 * 1024;
+    static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+
+    unsafe {
+        esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
+            // HEAP.as_ptr() as *mut u8,
+            &HEAP[0] as *const u8 as *mut u8,
+            HEAP_SIZE,
+            esp_alloc::MemoryCapability::Internal.into(),
+        ));
+    }
 }
 
 pub struct DevkitC {
@@ -80,6 +96,9 @@ impl BoardPeripherals for DevkitC {
 #[esp_rtos::main]
 async fn main(spawner: embassy_executor::Spawner) {
     esp_println::logger::init_logger_from_env();
+
+    init_heap();
+
     let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
     let peripherals = esp_hal::init(config);
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -6,7 +6,6 @@
     holding buffers for the duration of a data transfer."
 )]
 
-use embassy_executor::Spawner;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -20,7 +20,7 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
 }
 
 fn init_heap() {
-    const HEAP_SIZE: usize = 32 * 1024;
+    const HEAP_SIZE: usize = 128 * 1024;
     static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 
     unsafe {

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -1,13 +1,10 @@
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
-use embassy_time::{Duration, Timer};
 use esp_hal::Async;
 use esp_hal::uart::Uart;
 
 extern crate alloc;
-
-use nmea_parser::ParsedMessage;
 
 use alloc::string::String; // Need this import if using heap/alloc crate
 
@@ -18,7 +15,7 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
     let mut incomplete_line_buffer = String::new(); // Requires the 'alloc' crate to be used
 
     loop {
-        let mut buf = [0u8; 800];
+        let mut buf = [0u8; 500];
         let n = gps2_uart.read_async(&mut buf[..]).await.unwrap();
         let chunk = core::str::from_utf8(&buf[..n]).unwrap_or("");
 
@@ -43,15 +40,30 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
                     Ok(parsed_data) => {
                         match parsed_data {
                             nmea_parser::ParsedMessage::Gga(gga) => {
+                                if let Some(time) = gga.timestamp {
+                                    info!("GPS time is: {}", time);
+                                }
                                 info!(
-                                    "GPGGA FIX: Lat={}, Lon={}, HDOP={}",
+                                    "GPGGA FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
                                     gga.latitude.unwrap_or(0.0),
                                     gga.longitude.unwrap_or(0.0),
-                                    gga.hdop.unwrap_or(0.0)
+                                    gga.hdop.unwrap_or(0.0),
+                                    gga.satellite_count.unwrap_or(0),
                                 );
                             }
                             nmea_parser::ParsedMessage::Rmc(rmc) => {
                                 debug!("GPRMC Status: {:?}", rmc);
+                            }
+                            nmea_parser::ParsedMessage::Vtg(vtg) => {
+                                // Velocity over ground in knots (N) and kilometers per hour (K)
+                                let speed_knots = vtg.sog_knots.unwrap_or(0.0);
+                                let speed_kph = vtg.sog_kph.unwrap_or(0.0);
+                                let course = vtg.cog_true.unwrap_or(0.0);
+
+                                info!(
+                                    "GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
+                                    speed_knots, speed_kph, course
+                                );
                             }
                             _ => {} // Ignore other sentence types for now
                         }
@@ -63,8 +75,6 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
             }
         }
 
-        // 5. Update the incomplete buffer for the next iteration
         incomplete_line_buffer = String::from(next_buffer);
     }
 }
-

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -1,12 +1,62 @@
-#[allow(unused_imports)]
-use log::{debug, error, info, trace, warn};
+use core::fmt::Write;
 
 use esp_hal::Async;
 use esp_hal::uart::Uart;
+#[allow(unused_imports)]
+use log::{debug, error, info, trace, warn};
 
 extern crate alloc;
-
 use alloc::string::String; // Need this import if using heap/alloc crate
+
+const NMEA_0183_MAX_LENGTH: usize = 83;
+const MAX_SENTENCE_LENGTH: usize = NMEA_0183_MAX_LENGTH + 2; // give ourselves buffer for newlines
+
+// TODO: create initialization function which disables GSV/GSA/GLL messages
+// Then: make buffer sizing constant since we only receive RMC/VTG/GGA
+// --- NMEA Checksum function (from above) ---
+fn calculate_nmea_checksum(data: &[u8]) -> u8 {
+    let mut checksum: u8 = 0;
+    for byte in data {
+        checksum ^= *byte;
+    }
+    checksum
+}
+// ------------------------------------------
+
+async fn send_nmea_command(uart: &mut Uart<'static, Async>, payload: &str, name: &str) {
+    let checksum = calculate_nmea_checksum(payload.as_bytes());
+
+    let mut full_command: heapless::String<128> = heapless::String::new();
+
+    let result = write!(&mut full_command, "${}*{:02X}\r\n", payload, checksum);
+
+    let command_bytes = full_command.as_bytes();
+
+    match uart.write_async(command_bytes).await {
+        Ok(_) => info!(
+            "GPS Config: Sent command to disable {} ({})",
+            name,
+            full_command.trim()
+        ),
+        Err(e) => error!("GPS Config: Failed to send command for {}: {:?}", name, e),
+    }
+}
+
+pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uart<'static, Async> {
+    info!("Starting GPS configuration using $PUBX,40 commands...");
+
+    // The payloads (excluding the leading '$' and trailing '*cs')
+    const GSA_PAYLOAD: &str = "PUBX,40,GSA,0,0,0,0,0,0";
+    const GSV_PAYLOAD: &str = "PUBX,40,GSV,0,0,0,0,0,0";
+    const GLL_PAYLOAD: &str = "PUBX,40,GLL,0,0,0,0,0,0";
+
+    // Send commands to disable the unwanted messages (GSA, GSV, GLL)
+    send_nmea_command(&mut gps2_uart, GSA_PAYLOAD, "GSA").await;
+    send_nmea_command(&mut gps2_uart, GSV_PAYLOAD, "GSV").await;
+    send_nmea_command(&mut gps2_uart, GLL_PAYLOAD, "GLL").await;
+
+    gps2_uart
+}
 
 pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
     let mut parser = nmea_parser::NmeaParser::new();
@@ -16,7 +66,13 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
 
     loop {
         let mut buf = [0u8; 500];
-        let n = gps2_uart.read_async(&mut buf[..]).await.unwrap();
+        let n = match gps2_uart.read_async(&mut buf[..]).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!("UART Read Error: {:?}", e);
+                continue;
+            }
+        };
         let chunk = core::str::from_utf8(&buf[..n]).unwrap_or("");
 
         incomplete_line_buffer.push_str(chunk);
@@ -34,6 +90,14 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
 
         for line in sentences_to_parse {
             let sentence = line.trim(); // Clean up whitespace/newline residue
+            //
+            if sentence.len() < 5 || sentence.len() > NMEA_0183_MAX_LENGTH {
+                warn!(
+                    "Skipping non-compliant NMEA sentence (len={}): '{}'",
+                    sentence.len(),
+                    sentence
+                );
+            }
 
             if !sentence.is_empty() {
                 match parser.parse_sentence(sentence) {
@@ -64,7 +128,9 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
                                     speed_knots, speed_kph, course
                                 );
                             }
-                            _ => {} // Ignore other sentence types for now
+                            other_message => {
+                                info!("parsed message of type: {:?}", other_message);
+                            } // Ignore other sentence types for now
                         }
                     }
                     Err(e) => {
@@ -75,5 +141,9 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
         }
 
         incomplete_line_buffer = String::from(next_buffer);
+        if incomplete_line_buffer.len() > 1024 {
+            warn!("GPS Buffer overflow, clearing");
+            incomplete_line_buffer.clear();
+        }
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -5,19 +5,66 @@ use embassy_time::{Duration, Timer};
 use esp_hal::Async;
 use esp_hal::uart::Uart;
 
+extern crate alloc;
+
+use nmea_parser::ParsedMessage;
+
+use alloc::string::String; // Need this import if using heap/alloc crate
+
 pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
-    // let mut parser = nmea_parser::NmeaParser::new();
+    let mut parser = nmea_parser::NmeaParser::new();
+
+    // Use a String to buffer incomplete lines across loop iterations
+    let mut incomplete_line_buffer = String::new(); // Requires the 'alloc' crate to be used
 
     loop {
         let mut buf = [0u8; 800];
         let n = gps2_uart.read_async(&mut buf[..]).await.unwrap();
-        let line = core::str::from_utf8(&buf[..n]).unwrap_or("");
+        let chunk = core::str::from_utf8(&buf[..n]).unwrap_or("");
 
-        // if let Ok(msg) = parser.parse(line) {
-        //     if let nmea_parser::ParsedMessage::Rmc(rmc) = msg {
-        //         info!("Received RMC message: {}", msg);
-        //     }
-        // }
-        info!("GPS2 received {} bytes of information: \n{:?}\n", n, line);
+        incomplete_line_buffer.push_str(chunk);
+        let lines: alloc::vec::Vec<&str> = incomplete_line_buffer.split('\n').collect();
+
+        let (sentences_to_parse, next_buffer) = if incomplete_line_buffer.ends_with('\n') {
+            // If the buffer ended with a newline, all lines are complete
+            (lines, "")
+        } else {
+            // Otherwise, the last item in the vector is the incomplete line
+            let last_line = lines[lines.len() - 1];
+            let complete_lines = &lines[..lines.len() - 1];
+            (complete_lines.to_vec(), last_line)
+        };
+
+        for line in sentences_to_parse {
+            let sentence = line.trim(); // Clean up whitespace/newline residue
+
+            if !sentence.is_empty() {
+                match parser.parse_sentence(sentence) {
+                    Ok(parsed_data) => {
+                        match parsed_data {
+                            nmea_parser::ParsedMessage::Gga(gga) => {
+                                info!(
+                                    "GPGGA FIX: Lat={}, Lon={}, HDOP={}",
+                                    gga.latitude.unwrap_or(0.0),
+                                    gga.longitude.unwrap_or(0.0),
+                                    gga.hdop.unwrap_or(0.0)
+                                );
+                            }
+                            nmea_parser::ParsedMessage::Rmc(rmc) => {
+                                debug!("GPRMC Status: {:?}", rmc);
+                            }
+                            _ => {} // Ignore other sentence types for now
+                        }
+                    }
+                    Err(e) => {
+                        warn!("NMEA Parse Error: {} for sentence: '{}'", e, sentence);
+                    }
+                }
+            }
+        }
+
+        // 5. Update the incomplete buffer for the next iteration
+        incomplete_line_buffer = String::from(next_buffer);
     }
 }
+

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -47,6 +47,10 @@ async fn send_nmea_command(uart: &mut Uart<'static, Async>, payload: &str, name:
 pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uart<'static, Async> {
     info!("Starting GPS configuration using $PUBX,40 commands...");
 
+    // TODO: Configure GPS for 10hz updates & 115200 baud
+    // ONLY DO THIS WHEN THE NEW GPS COMES IN, since we will have to set baud rate at configuration
+    // time, meaning we must set the baud for all the gps's, then change the code, then use the GPS
+
     // The payloads (excluding the leading '$' and trailing '*cs')
     const GSA_PAYLOAD: &str = "PUBX,40,GSA,0,0,0,0,0,0";
     const GSV_PAYLOAD: &str = "PUBX,40,GSV,0,0,0,0,0,0";

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -1,0 +1,23 @@
+#[allow(unused_imports)]
+use log::{debug, error, info, trace, warn};
+
+use embassy_time::{Duration, Timer};
+use esp_hal::Async;
+use esp_hal::uart::Uart;
+
+pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
+    // let mut parser = nmea_parser::NmeaParser::new();
+
+    loop {
+        let mut buf = [0u8; 800];
+        let n = gps2_uart.read_async(&mut buf[..]).await.unwrap();
+        let line = core::str::from_utf8(&buf[..n]).unwrap_or("");
+
+        // if let Ok(msg) = parser.parse(line) {
+        //     if let nmea_parser::ParsedMessage::Rmc(rmc) = msg {
+        //         info!("Received RMC message: {}", msg);
+        //     }
+        // }
+        info!("GPS2 received {} bytes of information: \n{:?}\n", n, line);
+    }
+}

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -5,9 +5,6 @@ use heapless::String;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
-extern crate alloc;
-// use alloc::string::String; // Need this import if using heap/alloc crate
-
 const NMEA_0183_MAX_LENGTH: usize = 83;
 const MAX_SENTENCE_LENGTH: usize = NMEA_0183_MAX_LENGTH + 2; // give ourselves buffer for newlines
 const NUM_NMEA_SENTENCES: usize = 3; // RMC, VTG, GGA

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -40,9 +40,6 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
                     Ok(parsed_data) => {
                         match parsed_data {
                             nmea_parser::ParsedMessage::Gga(gga) => {
-                                if let Some(time) = gga.timestamp {
-                                    info!("GPS time is: {}", time);
-                                }
                                 info!(
                                     "GPGGA FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
                                     gga.latitude.unwrap_or(0.0),
@@ -52,7 +49,9 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
                                 );
                             }
                             nmea_parser::ParsedMessage::Rmc(rmc) => {
-                                debug!("GPRMC Status: {:?}", rmc);
+                                if let Some(time) = rmc.timestamp {
+                                    info!("GPS rmc time is: {}", time);
+                                }
                             }
                             nmea_parser::ParsedMessage::Vtg(vtg) => {
                                 // Velocity over ground in knots (N) and kilometers per hour (K)

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -1,19 +1,19 @@
 use core::fmt::Write;
-
 use esp_hal::Async;
 use esp_hal::uart::Uart;
+use heapless::String;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
 extern crate alloc;
-use alloc::string::String; // Need this import if using heap/alloc crate
+// use alloc::string::String; // Need this import if using heap/alloc crate
 
 const NMEA_0183_MAX_LENGTH: usize = 83;
 const MAX_SENTENCE_LENGTH: usize = NMEA_0183_MAX_LENGTH + 2; // give ourselves buffer for newlines
+const NUM_NMEA_SENTENCES: usize = 3; // RMC, VTG, GGA
+const CHUNK_BUFF_SIZE: usize = MAX_SENTENCE_LENGTH * (NUM_NMEA_SENTENCES + 1); // buffer
+const UNPROCESSED_BUFF_SIZE: usize = CHUNK_BUFF_SIZE * 2; // hold 2 chunks
 
-// TODO: create initialization function which disables GSV/GSA/GLL messages
-// Then: make buffer sizing constant since we only receive RMC/VTG/GGA
-// --- NMEA Checksum function (from above) ---
 fn calculate_nmea_checksum(data: &[u8]) -> u8 {
     let mut checksum: u8 = 0;
     for byte in data {
@@ -29,6 +29,11 @@ async fn send_nmea_command(uart: &mut Uart<'static, Async>, payload: &str, name:
     let mut full_command: heapless::String<128> = heapless::String::new();
 
     let result = write!(&mut full_command, "${}*{:02X}\r\n", payload, checksum);
+
+    if result.is_err() {
+        error!("Heapless string creation failed during PUBX message creation");
+        return;
+    }
 
     let command_bytes = full_command.as_bytes();
 
@@ -62,10 +67,11 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
     let mut parser = nmea_parser::NmeaParser::new();
 
     // Use a String to buffer incomplete lines across loop iterations
-    let mut incomplete_line_buffer = String::new(); // Requires the 'alloc' crate to be used
+    let mut incomplete_line_buffer: heapless::String<UNPROCESSED_BUFF_SIZE> =
+        heapless::String::new();
 
     loop {
-        let mut buf = [0u8; 500];
+        let mut buf = [0u8; CHUNK_BUFF_SIZE];
         let n = match gps2_uart.read_async(&mut buf[..]).await {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -76,74 +82,73 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
         let chunk = core::str::from_utf8(&buf[..n]).unwrap_or("");
 
         incomplete_line_buffer.push_str(chunk);
-        let lines: alloc::vec::Vec<&str> = incomplete_line_buffer.split('\n').collect();
 
-        let (sentences_to_parse, next_buffer) = if incomplete_line_buffer.ends_with('\n') {
-            // If the buffer ended with a newline, all lines are complete
-            (lines, "")
-        } else {
-            // Otherwise, the last item in the vector is the incomplete line
-            let last_line = lines[lines.len() - 1];
-            let complete_lines = &lines[..lines.len() - 1];
-            (complete_lines.to_vec(), last_line)
-        };
+        let mut start_idx = 0;
+        let mut sentences_processed = 0;
 
-        for line in sentences_to_parse {
-            let sentence = line.trim(); // Clean up whitespace/newline residue
-            //
+        while let Some(end_idx) = incomplete_line_buffer.as_str()[start_idx..].find('\n') {
+            let full_end_idx = start_idx + end_idx;
+            let line_slice = &incomplete_line_buffer.as_str()[start_idx..full_end_idx];
+
+            let sentence = line_slice.trim();
             if sentence.len() < 5 || sentence.len() > NMEA_0183_MAX_LENGTH {
-                warn!(
-                    "Skipping non-compliant NMEA sentence (len={}): '{}'",
+                warn! {
+                    "skipping non-compliant NMEA sentence (len={}): '{}'",
                     sentence.len(),
                     sentence
-                );
-            }
-
-            if !sentence.is_empty() {
+                }
+            } else if !sentence.is_empty() {
                 match parser.parse_sentence(sentence) {
-                    Ok(parsed_data) => {
-                        match parsed_data {
-                            nmea_parser::ParsedMessage::Gga(gga) => {
-                                info!(
-                                    "GPGGA FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
-                                    gga.latitude.unwrap_or(0.0),
-                                    gga.longitude.unwrap_or(0.0),
-                                    gga.hdop.unwrap_or(0.0),
-                                    gga.satellite_count.unwrap_or(0),
-                                );
-                            }
-                            nmea_parser::ParsedMessage::Rmc(rmc) => {
-                                if let Some(time) = rmc.timestamp {
-                                    info!("GPS rmc time is: {}", time);
-                                }
-                            }
-                            nmea_parser::ParsedMessage::Vtg(vtg) => {
-                                // Velocity over ground in knots (N) and kilometers per hour (K)
-                                let speed_knots = vtg.sog_knots.unwrap_or(0.0);
-                                let speed_kph = vtg.sog_kph.unwrap_or(0.0);
-                                let course = vtg.cog_true.unwrap_or(0.0);
-
-                                info!(
-                                    "GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
-                                    speed_knots, speed_kph, course
-                                );
-                            }
-                            other_message => {
-                                info!("parsed message of type: {:?}", other_message);
-                            } // Ignore other sentence types for now
+                    Ok(parsed_data) => match parsed_data {
+                        nmea_parser::ParsedMessage::Gga(gga) => {
+                            info!(
+                                "GPGGA FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
+                                gga.latitude.unwrap_or(0.0),
+                                gga.longitude.unwrap_or(0.0),
+                                gga.hdop.unwrap_or(0.0),
+                                gga.satellite_count.unwrap_or(0),
+                            );
                         }
-                    }
+                        nmea_parser::ParsedMessage::Rmc(rmc) => {
+                            if let Some(time) = rmc.timestamp {
+                                info!("GPS rmc time is: {}", time);
+                            }
+                        }
+                        nmea_parser::ParsedMessage::Vtg(vtg) => {
+                            let speed_knots = vtg.sog_knots.unwrap_or(0.0);
+                            let speed_kph = vtg.sog_kph.unwrap_or(0.0);
+                            let course = vtg.cog_true.unwrap_or(0.0);
+                            info!(
+                                "GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
+                                speed_knots, speed_kph, course
+                            );
+                        }
+                        other_message => {
+                            debug!("Ignoring other NMEA message type: {:?}", other_message);
+                        }
+                    },
                     Err(e) => {
                         warn!("NMEA Parse Error: {} for sentence: '{}'", e, sentence);
                     }
                 }
             }
+
+            start_idx = full_end_idx + 1;
+            sentences_processed += 1;
         }
 
-        incomplete_line_buffer = String::from(next_buffer);
-        if incomplete_line_buffer.len() > 1024 {
-            warn!("GPS Buffer overflow, clearing");
+        if start_idx < incomplete_line_buffer.len() {
+            let remainder = &incomplete_line_buffer.as_str()[start_idx..];
+
+            let mut next_buff: String<UNPROCESSED_BUFF_SIZE> = String::new();
+            if next_buff.push_str(remainder).is_err() {
+                error!("Heapless next buff push failed during remainder assignment");
+            }
+
             incomplete_line_buffer.clear();
+            incomplete_line_buffer = next_buff;
+        } else {
+            incomplete_line_buffer.clear(); // everything processed
         }
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -78,10 +78,12 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
         };
         let chunk = core::str::from_utf8(&buf[..n]).unwrap_or("");
 
-        incomplete_line_buffer.push_str(chunk);
+        if incomplete_line_buffer.push_str(chunk).is_err() {
+            warn!("Did not succesfully push chunk to incomplete_line_buffer..continuing anyways");
+        }
 
         let mut start_idx = 0;
-        let mut sentences_processed = 0;
+        let mut _sentences_processed = 0;
 
         while let Some(end_idx) = incomplete_line_buffer.as_str()[start_idx..].find('\n') {
             let full_end_idx = start_idx + end_idx;
@@ -131,7 +133,7 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
             }
 
             start_idx = full_end_idx + 1;
-            sentences_processed += 1;
+            _sentences_processed += 1;
         }
 
         if start_idx < incomplete_line_buffer.len() {

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 use crate::hmi::neopixel::NeoPixel;
-use core::future::Future;
 use esp_hal::Async;
 use esp_hal::gpio::Output;
 use esp_hal::uart::Uart;

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -9,6 +9,7 @@ pub mod asm330;
 pub mod gps;
 pub mod hmi;
 pub mod old_asm330;
+pub mod types;
 
 pub trait BoardPeripherals {
     fn take_user_led(&mut self) -> Output<'static>;

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -2,7 +2,9 @@
 
 use crate::hmi::neopixel::NeoPixel;
 use core::future::Future;
+use esp_hal::Async;
 use esp_hal::gpio::Output;
+use esp_hal::uart::Uart;
 
 pub mod app;
 pub mod asm330;
@@ -14,4 +16,6 @@ pub mod types;
 pub trait BoardPeripherals {
     fn take_user_led(&mut self) -> Output<'static>;
     fn take_neopixel(&mut self) -> NeoPixel<'static>;
+
+    fn take_gps2_uart(&mut self) -> Uart<'static, Async>;
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/old_asm330.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/old_asm330.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use embedded_hal::spi::SpiBus;
-use log::{debug, info, trace};
+use log::{debug, info};
 
 // ----- Register Addresses -----
 // --- FIFO ---

--- a/sw/sensor_board/sensor_board_rev1_test/src/types.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/types.rs
@@ -1,2 +1,21 @@
 /// types.rs
 /// Defines all of the common datatypes (IMU/GPS/FUSE/etc)
+
+pub struct GpsTime {
+    pub year: u16,
+    pub month: u8,
+    pub day: u8,
+    pub hours: u8,
+    pub minutes: u8,
+    pub seconds: u8,
+    pub millis: u16,
+}
+
+pub struct GpsData {
+    pub lat: f64,
+    pub lon: f64,
+    pub alt: f32,
+    pub speed_kts: f32,
+    pub heading: u16,
+    pub utc_time: GpsTime,
+}


### PR DESCRIPTION
# Overview
Builds off of #25. Adds support for generic gps message parsing using `nmea-parser` library for **gps2** on **uart1**. Port `nmea-parser` library to be SERDE free.

- Why is timestamp off....

## List of Breaking Changes
- ESP ALLOC means we now need to initialize a global heap allocator, I don't think this exists for `main.rs` yet and it doesn't build. 
- log! uses heap allocation and once we define a max heap size we can shoot ourselves in the foot pretty easily


## Testing
Tested locally on an esp32c6-devkit with UART1 configuration as specifiec (GPIO22/23). verified that data output ~ roughly ~ matches output observed from logic analyzer

<img width="809" height="687" alt="image" src="https://github.com/user-attachments/assets/665c5ffb-0af6-46f8-978c-53ba563a99ae" />

<img width="1532" height="1147" alt="image" src="https://github.com/user-attachments/assets/1deb8809-5abf-4a67-99c5-0c637c04a845" />
<img width="1919" height="1199" alt="image" src="https://github.com/user-attachments/assets/89679937-9401-4fc8-b95b-d518da6e4451" />
<img width="1915" height="1029" alt="image" src="https://github.com/user-attachments/assets/3ae49b58-b714-4ca1-91d3-1e4e26f8bd92" />



# FUTURE WORK
**Platform wise:**
- Switch from `log!` to `defmt!` using RTT or UART (potentially UART0?)
- Port `main.rs` for sensorboard over to new framework

**Driver wise:**
- Pull out anything heap-allocated, and re-jig nmea-parser to be lighter.

**GPS specific Features:**
- Add GPS1 support to LP_UART
- Create buffers to send GPS information to currently non-existent `fusion` library.