### PR TITLE
neopixel code refactor

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
@@ -33,23 +33,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bitfield"
-version = "0.19.3"
+name = "base64"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf79f42d21f18b5926a959280215903e659760da994835d27c3a0c5ff4f898f"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "bitfield"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6115af052c7914c0cbb97195e5c72cb61c511527250074f5c041d1048b0d8b16"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -98,6 +104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,9 +117,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -144,7 +156,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -157,7 +169,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -168,7 +180,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -179,18 +191,18 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "delegate"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -249,7 +261,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -433,7 +445,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -444,28 +456,30 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-alloc"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e95f1de57ce5a6600368f3d3c931b0dfe00501661e96f5ab83bc5cdee031784"
+version = "0.9.0"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "allocator-api2 0.3.1",
  "cfg-if",
- "critical-section",
  "document-features",
  "enumset",
+ "esp-config",
+ "esp-sync",
  "linked_list_allocator",
+ "rlsf",
 ]
 
 [[package]]
 name = "esp-bootloader-esp-idf"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c319c4a24fb44ef4c5f9854ff3dc6010eb8f15a6613d024227aa2355e3f6a334"
+version = "0.4.0"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "cfg-if",
  "document-features",
  "embedded-storage",
  "esp-config",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
  "esp-rom-sys",
  "jiff",
  "strum",
@@ -474,8 +488,7 @@ dependencies = [
 [[package]]
 name = "esp-config"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102871054f8dd98202177b9890cb4b71d0c6fe1f1413b7a379a8e0841fc2473c"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -487,8 +500,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54786287c0a61ca0f78cb0c338a39427551d1be229103b4444591796c579e093"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "bitfield",
  "bitflags",
@@ -540,40 +552,26 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e025a7a7a0affdb4ff913b5c4494aef96ee03d085bf83c27453ae3a71d50da6"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "document-features",
  "object",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "termcolor",
-]
-
-[[package]]
-name = "esp-hal-smartled2"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a00c36869076635bf254dee6f78ac8b9d3fa71541470538a8fffbdb626d120"
-dependencies = [
- "esp-hal",
- "num-traits",
- "smart-leds-trait",
 ]
 
 [[package]]
 name = "esp-metadata-generated"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 
 [[package]]
 name = "esp-println"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a30e6c9fbcc01c348d46706fef8131c7775ab84c254a3cd65d0cd3f6414d592"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -583,10 +581,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-radio-rtos-driver"
+version = "0.2.0"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+dependencies = [
+ "cfg-if",
+ "esp-sync",
+ "portable-atomic",
+]
+
+[[package]]
 name = "esp-riscv-rt"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502744a5b1e7268d27fd2a4e56ad45efe42ead517d6c517a6961540de949b0ee"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "document-features",
  "riscv",
@@ -596,8 +603,7 @@ dependencies = [
 [[package]]
 name = "esp-rom-sys"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd66cccc6dd2d13e9f33668a57717ab14a6d217180ec112e6be533de93e7ecbf"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -607,19 +613,22 @@ dependencies = [
 [[package]]
 name = "esp-rtos"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
+ "allocator-api2 0.3.1",
  "cfg-if",
  "document-features",
  "embassy-executor",
  "embassy-sync 0.7.2",
  "embassy-time-driver",
  "embassy-time-queue-utils",
+ "esp-alloc",
  "esp-config",
  "esp-hal",
  "esp-hal-procmacros",
  "esp-metadata-generated",
+ "esp-radio-rtos-driver",
+ "esp-rom-sys",
  "esp-sync",
  "portable-atomic",
 ]
@@ -627,8 +636,7 @@ dependencies = [
 [[package]]
 name = "esp-sync"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44974639b4e88914f83fe60d2832c00276657d7d857628fdfc966cc7302e8a8"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -717,9 +725,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fugit"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
+checksum = "4e639847d312d9a82d2e75b0edcc1e934efcc64e6cb7aa94f0b1fbec0bc231d6"
 dependencies = [
  "gcd",
 ]
@@ -768,9 +776,9 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -797,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heapless"
@@ -835,12 +843,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -854,15 +862,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
  "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -873,27 +881,33 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.178"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "linked_list_allocator"
@@ -909,9 +923,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -1022,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -1048,12 +1062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 
 [[package]]
-name = "rgb"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
-
-[[package]]
 name = "riscv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,7 +1082,7 @@ checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1103,7 +1111,7 @@ checksum = "15c3138fdd8d128b2d81829842a3e0ce771b3712f7b6318ed1476b0695e7d330"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1111,6 +1119,18 @@ name = "riscv-target-parser"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
+
+[[package]]
+name = "rlsf"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "svgbobdoc",
+]
 
 [[package]]
 name = "rustversion"
@@ -1138,13 +1158,11 @@ dependencies = [
  "esp-alloc",
  "esp-bootloader-esp-idf",
  "esp-hal",
- "esp-hal-smartled2",
  "esp-println",
  "esp-rtos",
  "heapless 0.9.2",
  "log",
  "nmea-parser",
- "smart-leds",
  "static_cell",
 ]
 
@@ -1175,7 +1193,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1189,24 +1207,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "smart-leds"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66df34e571fa9993fa6f99131a374d58ca3d694b75f9baac93458fe0d6057bf0"
-dependencies = [
- "smart-leds-trait",
-]
-
-[[package]]
-name = "smart-leds-trait"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f4441a131924d58da6b83a7ad765c460e64630cce504376c3a87a2558c487f"
-dependencies = [
- "rgb",
 ]
 
 [[package]]
@@ -1263,14 +1263,38 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "svgbobdoc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
+dependencies = [
+ "base64",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-width",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1303,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1339,6 +1363,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1390,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -1409,8 +1439,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "critical-section",
 ]
@@ -1418,8 +1447,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8709f037fb123fe7ff146d2bce86f9dc0dfc53045c016bfd9d703317b6502845"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "document-features",
  "xtensa-lx",
@@ -1429,12 +1457,11 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1454,5 +1481,5 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -9,23 +9,26 @@ default-run  = "sensor_board_rev1_test"
 name = "sensor_board_rev1_test"
 path = "./src/bin/sensorboard_rev1.rs"
 
+[[bin]]
+name = "devkit_c"
+path = "./src/bin/devkit_c.rs"
+
 [dependencies]
-esp-hal = { version = "1.0.0", features = ["esp32c6", "log-04", "unstable"] }
+# esp-hal ecosystem - using git directly until crates.io catches up with async RMT API
+# TODO: Switch to version-based deps + [patch.crates-io] when versions align
+# See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#using-patch-with-multiple-versions
+esp-hal = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-hal", features = ["esp32c6", "log-04", "unstable"] }
+esp-rtos = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-rtos", features = ["esp32c6", "esp-alloc", "embassy"] }
+esp-alloc = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-alloc" }
+esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-bootloader-esp-idf", features = ["esp32c6"] }
+esp-println = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-println", features = ["esp32c6", "log-04"] }
 
-
-esp-bootloader-esp-idf = { version = "0.3.0", features = ["esp32c6"] }
-log                    = "0.4.27"
-
+log = "0.4.27"
 critical-section = "1.2.0"
-esp-println      = { version = "0.16.0", features = ["esp32c6", "log-04"] }
 embedded-hal = "1.0.0"
-esp-hal-smartled2 = "0.28.1"
-smart-leds = "0.4"
-esp-rtos = { version = "0.2.0", features = ["embassy", "esp32c6"] }
 embassy-executor = "0.9.1"
 embassy-time = "0.5.0"
-nmea-parser = {path="../../Drivers/nmea-parser/", default-features=false, features = []}
-esp-alloc = "0.8.0"
+nmea-parser = { path = "../../Drivers/nmea-parser/", default-features = false, features = [] }
 heapless = "0.9.2"
 embassy-embedded-hal = "0.5.0"
 static_cell = "2.1.1"
@@ -46,5 +49,7 @@ lto              = 'fat'
 opt-level        = 's'
 overflow-checks  = false
 
+# Patch esp-hal-procmacros for compatibility with git dependencies
 [patch.crates-io]
-# nmea-parser = { git="https://github.com/mrdxxm/nmea-parser.git", branch="no_std"}
+esp-hal = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-hal" }
+esp-hal-procmacros = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-hal-procmacros" }

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -25,6 +25,7 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
+// Required by the ESP-IDF bootloader
 esp_bootloader_esp_idf::esp_app_desc!();
 
 fn init_heap() {
@@ -33,7 +34,6 @@ fn init_heap() {
 
     unsafe {
         esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
-            // HEAP.as_ptr() as *mut u8,
             &HEAP[0] as *const u8 as *mut u8,
             HEAP_SIZE,
             esp_alloc::MemoryCapability::Internal.into(),
@@ -58,7 +58,6 @@ impl DevkitC {
             esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
         esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
-        debug!(">>> building DevkitC");
 
         let user_led = esp_hal::gpio::Output::new(
             peripherals.GPIO19,
@@ -66,12 +65,12 @@ impl DevkitC {
             esp_hal::gpio::OutputConfig::default(),
         );
 
-        let rmt =
-            esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80)).unwrap();
+        let rmt = esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80))
+            .unwrap()
+            .into_async();
         let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO8);
 
         let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(9600);
-        info!("baudrate for gps2_uart_set");
         let gps2_uart = esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
             .unwrap()
             .with_rx(peripherals.GPIO23)
@@ -100,8 +99,6 @@ impl DevkitC {
         );
         let imu_spi_device = SpiDevice::new(spi_bus, imu_spi2_cs);
         let disp_spi_device = SpiDevice::new(spi_bus, disp_spi2_cs);
-
-        debug!(">>> devkitC returned things correctly");
         Self {
             user_led: Some(user_led),
             neopixel: Some(neopixel),
@@ -150,7 +147,6 @@ async fn main(spawner: embassy_executor::Spawner) {
     let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    info!("Configuration complete - running app?");
     app_run(spawner, DevkitC::from_peripherals(peripherals)).await;
     loop {
         embassy_time::Timer::after_secs(1).await

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -33,8 +33,8 @@ pub async fn start_hmi(
             }
             led_on = !led_on;
 
-            // Update NeoPixel color
-            neopixel.set_color_with_brightness(color, neopixel_brightness);
+            // Update NeoPixel color (async)
+            neopixel.set_color_with_brightness(color, neopixel_brightness).await;
 
             // Wait for the next tick based on rate
             Timer::after(period).await;

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/neopixel.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/neopixel.rs
@@ -1,9 +1,14 @@
-//! Simple no-std NeoPixel/WS2812 driver for ESP32-C6
+//! Async WS2812/NeoPixel driver using ESP32 RMT peripheral.
+//!
+//! # References
+//! - WS2812B Datasheet: <https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf>
+//! - esp-hal RMT examples: <https://github.com/esp-rs/esp-hal/tree/main/examples>
 
-use esp_hal::gpio::OutputPin;
-use esp_hal_smartled::{RmtSmartLeds, Ws2812Timing, buffer_size, color_order};
-use smart_leds::{SmartLedsWrite, RGB8};
+use esp_hal::gpio::{Level, OutputPin};
+use esp_hal::rmt::{Channel, PulseCode, TxChannelConfig, TxChannelCreator, Tx};
+use log::warn;
 
+/// Simple color enum for a single NeoPixel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Color {
     Off,
@@ -20,8 +25,6 @@ pub enum Color {
 }
 
 impl Color {
-    /// Get an array of all predefined colors (excluding Off and Custom)
-    /// Useful for cycling through colors in animations
     pub const fn all_colors() -> [Color; 9] {
         [
             Color::Red,
@@ -36,7 +39,6 @@ impl Color {
         ]
     }
 
-    /// Convert Color to a RGB values tuple
     pub const fn to_rgb(&self) -> (u8, u8, u8) {
         match self {
             Color::Off => (0, 0, 0),
@@ -52,60 +54,101 @@ impl Color {
             Color::Custom(r, g, b) => (*r, *g, *b),
         }
     }
-
-    /// Convert to RGB8 type used by smart-leds
-    fn to_rgb8(&self) -> RGB8 {
-        let (r, g, b) = self.to_rgb();
-        RGB8 { r, g, b }
-    }
 }
 
-/// NeoPixel driver - wraps RmtSmartLeds for single LED control
+/// Minimal NeoPixel driver built directly on esp-hal RMT async channel.
 pub struct NeoPixel<'d> {
-    led: RmtSmartLeds<'d, { buffer_size::<RGB8>(1) }, esp_hal::Blocking, RGB8, color_order::Grb, Ws2812Timing>,
+    channel: Channel<'d, esp_hal::Async, Tx>,
+    buffer: [PulseCode; NeoPixel::FRAME_LEN],
 }
 
 impl<'d> NeoPixel<'d> {
-    /// Create new NeoPixel driver using an RMT channel
-    /// 
-    /// # Example
-    /// ```ignore
-    /// let rmt = Rmt::new(peripherals.RMT, 80.MHz()).unwrap();
-    /// let mut neopixel = NeoPixel::new(rmt.channel0, io.pins.gpio18);
-    /// ```
+    // 24 bits + reset + end marker
+    const FRAME_LEN: usize = 26;
+
+    /// Create a new NeoPixel driver from an RMT TX channel and GPIO pin.
     pub fn new<CH, P>(channel: CH, pin: P) -> Self
     where
-        CH: esp_hal::rmt::TxChannelCreator<'d, esp_hal::Blocking>,
+        CH: TxChannelCreator<'d, esp_hal::Async>,
         P: OutputPin + 'd,
     {
-        let led = RmtSmartLeds::new_with_memsize(channel, pin, 2).unwrap();
-        Self { led }
+        // Configure RMT for WS2812: clock divider of 1 gives us 80MHz ticks (12.5ns each)
+        // Enable idle output so the line goes low after transmission
+        let config = TxChannelConfig::default()
+            .with_clk_divider(1)
+            .with_idle_output_level(Level::Low)
+            .with_idle_output(true);
+        
+        let tx = channel
+            .configure_tx(&config)
+            .unwrap()
+            .with_pin(pin);
+
+        Self {
+            channel: tx,
+            buffer: [PulseCode::end_marker(); NeoPixel::FRAME_LEN],
+        }
     }
 
-    /// Set the NeoPixel to a specific color
-    pub fn set_color(&mut self, color: Color) {
-        let rgb = color.to_rgb8();
-        let _ = self.led.write([rgb].iter().cloned());
+    /// Async set color (non-blocking RMT transfer).
+    pub async fn set_color(&mut self, color: Color) {
+        self.fill_buffer(color);
+        if let Err(e) = self.channel.transmit(&self.buffer).await {
+            warn!("[NeoPixel] Transmit error: {:?}", e);
+        }
     }
-    
-    /// Set color with brightness scaling
-    /// 
-    /// # Arguments
-    /// * `color` - The color to display
-    /// * `brightness` - Brightness level from 0 (off) to 255 (full brightness)
-    pub fn set_color_with_brightness(&mut self, color: Color, brightness: u8) {
+
+    /// Async set color with brightness scaling (0-255).
+    pub async fn set_color_with_brightness(&mut self, color: Color, brightness: u8) {
         let (r, g, b) = color.to_rgb();
         let scale = brightness as u16;
-        
         let r_scaled = ((r as u16 * scale) / 255) as u8;
         let g_scaled = ((g as u16 * scale) / 255) as u8;
         let b_scaled = ((b as u16 * scale) / 255) as u8;
-        
-        self.set_color(Color::Custom(r_scaled, g_scaled, b_scaled));
+        self.set_color(Color::Custom(r_scaled, g_scaled, b_scaled)).await;
     }
 
-    /// Turn off the NeoPixel
-    pub fn clear(&mut self) {
-        self.set_color(Color::Off);
+    pub async fn clear(&mut self) {
+        self.set_color(Color::Off).await;
+    }
+
+    fn fill_buffer(&mut self, color: Color) {
+        // WS2812B timing @ 80MHz RMT clock (12.5ns per tick)
+        // Reference: WS2812B Datasheet - Data Transfer Time
+        //   T0H: 0.4us ±150ns (high for 0-bit)
+        //   T0L: 0.85us ±150ns (low for 0-bit)  
+        //   T1H: 0.8us ±150ns (high for 1-bit)
+        //   T1L: 0.45us ±150ns (low for 1-bit)
+        //   RES: >50us (reset/latch)
+        const T0H: u16 = 28;   // 0.35us (28 * 12.5ns)
+        const T0L: u16 = 64;   // 0.80us (64 * 12.5ns)
+        const T1H: u16 = 56;   // 0.70us (56 * 12.5ns)
+        const T1L: u16 = 48;   // 0.60us (48 * 12.5ns)
+        const RESET: u16 = 4000; // 50us (4000 * 12.5ns)
+
+        let (r, g, b) = color.to_rgb();
+        // WS2812 wants GRB order
+        let bits = [
+            g, r, b,
+        ];
+
+        let mut idx = 0;
+        for byte in bits {
+            for bit in (0..8).rev() {
+                let one = (byte >> bit) & 1 == 1;
+                let code = if one {
+                    PulseCode::new(Level::High, T1H, Level::Low, T1L)
+                } else {
+                    PulseCode::new(Level::High, T0H, Level::Low, T0L)
+                };
+                self.buffer[idx] = code;
+                idx += 1;
+            }
+        }
+        // reset/latch pulse (50us low, then a tiny low pulse to avoid length2=0 looking like end marker)
+        self.buffer[idx] = PulseCode::new(Level::Low, RESET, Level::Low, 1);
+        idx += 1;
+        // end marker
+        self.buffer[idx] = PulseCode::end_marker();
     }
 }


### PR DESCRIPTION
Refactored the neopixel library code to remove its dependency to the smart led crate, enhanced its async compatibility. Setting up the dependency for adapting esp-now.
- esp wifi init doesn't like esp-hal 1.0.0
- Pinned a specific esp-hal upstream commit as temporary solution until they release something newer
- The new upstream code uses new asyc RMT api
-Neopixel now running custom code instead of smart led code
