### PR TITLE
Aircomm, esp now sending heartbeat

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
@@ -1237,6 +1237,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 name = "sensor_board_rev1_test"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "critical-section",
  "embassy-embedded-hal",
  "embassy-executor",

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
@@ -286,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-net-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
+
+[[package]]
 name = "embassy-sync"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,7 +463,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "esp-alloc"
 version = "0.9.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "allocator-api2 0.3.1",
  "cfg-if",
@@ -472,7 +478,7 @@ dependencies = [
 [[package]]
 name = "esp-bootloader-esp-idf"
 version = "0.4.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -488,7 +494,7 @@ dependencies = [
 [[package]]
 name = "esp-config"
 version = "0.6.1"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -500,7 +506,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "1.0.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "bitfield",
  "bitflags",
@@ -552,7 +558,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.21.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "document-features",
  "object",
@@ -566,12 +572,26 @@ dependencies = [
 [[package]]
 name = "esp-metadata-generated"
 version = "0.3.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
+
+[[package]]
+name = "esp-phy"
+version = "0.1.1"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
+dependencies = [
+ "cfg-if",
+ "document-features",
+ "esp-config",
+ "esp-hal",
+ "esp-metadata-generated",
+ "esp-sync",
+ "esp-wifi-sys-esp32c6",
+]
 
 [[package]]
 name = "esp-println"
 version = "0.16.1"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -581,9 +601,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-radio"
+version = "0.17.0"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
+dependencies = [
+ "allocator-api2 0.3.1",
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-net-driver",
+ "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
+ "enumset",
+ "esp-alloc",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-phy",
+ "esp-radio-rtos-driver",
+ "esp-sync",
+ "esp-wifi-sys-esp32c6",
+ "heapless 0.9.2",
+ "instability",
+ "num-derive",
+ "num-traits",
+ "portable-atomic",
+ "portable_atomic_enum",
+]
+
+[[package]]
 name = "esp-radio-rtos-driver"
 version = "0.2.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "cfg-if",
  "esp-sync",
@@ -593,7 +645,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.13.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "document-features",
  "riscv",
@@ -603,7 +655,7 @@ dependencies = [
 [[package]]
 name = "esp-rom-sys"
 version = "0.1.3"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -613,7 +665,7 @@ dependencies = [
 [[package]]
 name = "esp-rtos"
 version = "0.2.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "allocator-api2 0.3.1",
  "cfg-if",
@@ -636,7 +688,7 @@ dependencies = [
 [[package]]
 name = "esp-sync"
 version = "0.1.1"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -646,6 +698,11 @@ dependencies = [
  "riscv",
  "xtensa-lx",
 ]
+
+[[package]]
+name = "esp-wifi-sys-esp32c6"
+version = "0.1.0"
+source = "git+https://github.com/esp-rs/esp-wifi-sys?rev=7623c8d#7623c8d746b55cd8d9f7473359069aef381b7d3b"
 
 [[package]]
 name = "esp32"
@@ -960,6 +1017,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1082,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "portable_atomic_enum"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d48f60c43e0120bb2bb48589a16d4bed2f4b911be41e299f2d0fc0e0e20885"
+dependencies = [
+ "portable-atomic",
+ "portable_atomic_enum_macros",
+]
+
+[[package]]
+name = "portable_atomic_enum_macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33fa6ec7f2047f572d49317cca19c87195de99c6e5b6ee492da701cfe02b053"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1159,6 +1248,7 @@ dependencies = [
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-println",
+ "esp-radio",
  "esp-rtos",
  "heapless 0.9.2",
  "log",
@@ -1439,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx"
 version = "0.13.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "critical-section",
 ]
@@ -1447,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt"
 version = "0.21.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "document-features",
  "xtensa-lx",
@@ -1457,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.5.0"
-source = "git+https://github.com/esp-rs/esp-hal?branch=main#b81533a8b40cc2b99dd867564520abc09c25f348"
+source = "git+https://github.com/esp-rs/esp-hal?branch=main#10025b6b26c07e482abf7ae7b6c1699a4c86b84e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -33,6 +33,7 @@ embassy-executor = "0.9.1"
 embassy-time = "0.5.0"
 nmea-parser = { path = "../../Drivers/nmea-parser/", default-features = false, features = [] }
 heapless = "0.9.2"
+byteorder = { version = "1.5", default-features = false }
 embassy-embedded-hal = "0.5.0"
 static_cell = "2.1.1"
 embassy-sync = "0.7.2"

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -5,6 +5,13 @@ rust-version = "1.88"
 version      = "0.1.0"
 default-run  = "sensor_board_rev1_test"
 
+[features]
+default = ["hmi", "imu", "gps", "wifi"]
+hmi = []      # User LED, NeoPixel, Display
+imu = []      # IMU sensor (SPI)
+gps = []      # GPS sensor (UART)
+wifi = []     # WiFi/ESP-NOW wireless communication
+
 [[bin]]
 name = "sensor_board_rev1_test"
 path = "./src/bin/sensorboard_rev1.rs"

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -18,10 +18,13 @@ path = "./src/bin/devkit_c.rs"
 # TODO: Switch to version-based deps + [patch.crates-io] when versions align
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#using-patch-with-multiple-versions
 esp-hal = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-hal", features = ["esp32c6", "log-04", "unstable"] }
-esp-rtos = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-rtos", features = ["esp32c6", "esp-alloc", "embassy"] }
+esp-rtos = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-rtos", features = ["esp32c6", "esp-alloc", "embassy", "esp-radio"] }
 esp-alloc = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-alloc" }
 esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-bootloader-esp-idf", features = ["esp32c6"] }
 esp-println = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-println", features = ["esp32c6", "log-04"] }
+
+# ESP-NOW wireless communication
+esp-radio = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-radio", features = ["esp32c6", "esp-now", "unstable", "esp-alloc"] }
 
 log = "0.4.27"
 critical-section = "1.2.0"

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/error.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/error.rs
@@ -1,0 +1,41 @@
+//! Error types for the air communication module
+
+use core::fmt;
+use esp_radio::esp_now::EspNowError;
+
+/// Result type for AirComm operations
+pub type Result<T> = core::result::Result<T, AirCommError>;
+
+/// Errors that can occur in the air communication module
+#[derive(Debug)]
+pub enum AirCommError {
+    /// ESP-NOW underlying error
+    EspNowError(EspNowError),
+    
+    /// Buffer too small for serialization
+    BufferTooSmall,
+    
+    /// Invalid message format
+    InvalidMessage,
+    
+    /// Unknown message type
+    UnknownMessageType,
+}
+
+impl fmt::Display for AirCommError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AirCommError::EspNowError(e) => write!(f, "ESP-NOW error: {}", e),
+            AirCommError::BufferTooSmall => write!(f, "Buffer too small for serialization"),
+            AirCommError::InvalidMessage => write!(f, "Invalid message format"),
+            AirCommError::UnknownMessageType => write!(f, "Unknown message type"),
+        }
+    }
+}
+
+impl From<EspNowError> for AirCommError {
+    fn from(e: EspNowError) -> Self {
+        AirCommError::EspNowError(e)
+    }
+}
+

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
@@ -1,0 +1,106 @@
+//! Message definitions for sensor data communication
+//!
+//! This module defines the data structures and message types for various
+//! sensor data that can be transmitted over ESP-NOW.
+
+// Re-export sensor data types from types module
+pub use crate::types::{GpsData, ImuData};
+
+/// Message type discriminator (1 byte)
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageType {
+    /// IMU sensor data
+    Imu = 0x01,
+    /// GPS sensor data
+    Gps = 0x02,
+    /// Heartbeat/keep-alive message
+    Heartbeat = 0xFF,
+}
+
+impl MessageType {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0x01 => Some(MessageType::Imu),
+            0x02 => Some(MessageType::Gps),
+            0xFF => Some(MessageType::Heartbeat),
+            _ => None,
+        }
+    }
+
+    pub fn to_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Heartbeat message data structure
+///
+/// Contains a magic byte for validation. Timestamp is at the SensorMessage level.
+#[derive(Debug, Clone, Copy)]
+pub struct HeartbeatData {
+    /// Magic byte for validation (typically 0x42 or custom value)
+    pub magic: u8,
+}
+
+impl HeartbeatData {
+    /// Size in bytes when serialized
+    pub const SERIALIZED_SIZE: usize = 1; // magic only
+    
+    /// Default magic byte value
+    pub const DEFAULT_MAGIC: u8 = 0x42;
+    
+    /// Create a new heartbeat with magic byte
+    ///
+    /// # Arguments
+    /// * `magic` - Magic byte for validation
+    pub fn new(magic: u8) -> Self {
+        Self { magic }
+    }
+    
+    /// Create a new heartbeat with default magic byte
+    pub fn default() -> Self {
+        Self::new(Self::DEFAULT_MAGIC)
+    }
+}
+
+// Serialization sizes for aircomm protocol (payload only, excluding header)
+// Header is always: message_type(1) + timestamp(8) = 9 bytes
+// HeartbeatData: magic(1) = 1 byte (timestamp moved to message level)
+// ImuData: TBD (timestamp moved to message level)
+pub const IMU_SERIALIZED_SIZE: usize = 0; // TODO: Update when IMU fields are implemented
+// GpsTime: year(2) + month(1) + day(1) + hours(1) + minutes(1) + seconds(1) + millis(2) = 9 bytes
+pub const GPS_TIME_SERIALIZED_SIZE: usize = 2 + 1 + 1 + 1 + 1 + 1 + 2;
+// GpsData: lat(8) + lon(8) + alt(4) + speed(4) + heading(2) + time(9) = 35 bytes
+pub const GPS_SERIALIZED_SIZE: usize = 8 + 8 + 4 + 4 + 2 + GPS_TIME_SERIALIZED_SIZE;
+
+/// Unified sensor message structure
+///
+/// Represents any type of sensor data with unified timestamp at message level
+#[derive(Debug, Clone)]
+pub struct SensorMessage {
+    /// Source MAC address
+    pub src_address: [u8; 6],
+    /// Sender's timestamp in microseconds (when message was created)
+    pub timestamp_us: u64,
+    /// Message payload
+    pub payload: SensorPayload,
+}
+
+/// Sensor message payload
+#[derive(Debug, Clone)]
+pub enum SensorPayload {
+    Imu(ImuData),
+    Gps(GpsData),
+    Heartbeat(HeartbeatData),
+}
+
+impl SensorPayload {
+    pub fn message_type(&self) -> MessageType {
+        match self {
+            SensorPayload::Imu(_) => MessageType::Imu,
+            SensorPayload::Gps(_) => MessageType::Gps,
+            SensorPayload::Heartbeat(_) => MessageType::Heartbeat,
+        }
+    }
+}
+

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
@@ -1,0 +1,88 @@
+//! Air Communication Module
+//!
+//! This module provides a high-level interface for wireless communication
+//! between ESP devices using ESP-NOW protocol. It wraps esp-hal's ESP-NOW
+//! functionality to provide easy-to-use methods for sending and receiving
+//! sensor data (IMU, GPS, etc.).
+
+mod receiver;
+mod sender;
+
+pub mod error;
+pub mod message;
+pub mod protocol;
+
+pub use error::{AirCommError, Result};
+pub use message::{GpsData, HeartbeatData, ImuData, MessageType, SensorMessage, SensorPayload};
+pub use sender::BROADCAST;
+
+use esp_radio::esp_now::{EspNow, EspNowWifiInterface, PeerInfo};
+
+/// Main transceiver for wireless sensor data communication
+///
+/// This is the primary interface for ESP-NOW communication. It handles
+/// both sending and receiving sensor data, as well as peer management.
+pub struct AirCommTransceiver<'a> {
+    esp_now: EspNow<'a>,
+}
+
+impl<'a> AirCommTransceiver<'a> {
+    /// Initialize the air communication transceiver
+    pub fn new(esp_now: EspNow<'a>) -> Result<Self> {
+        Ok(Self { esp_now })
+    }
+
+    /// Send a heartbeat message
+    pub async fn send_heartbeat(
+        &mut self,
+        timestamp_us: u64,
+        data: &HeartbeatData,
+        peer_addr: &[u8; 6],
+    ) -> Result<()> {
+        sender::send_heartbeat(&mut self.esp_now, timestamp_us, data, peer_addr).await
+    }
+
+    /// Send IMU data to a peer
+    #[allow(dead_code)]
+    pub async fn send_imu(&mut self, timestamp_us: u64, data: &ImuData, peer_addr: &[u8; 6]) -> Result<()> {
+        sender::send_imu(&mut self.esp_now, timestamp_us, data, peer_addr).await
+    }
+
+    /// Send GPS data to a peer
+    #[allow(dead_code)]
+    pub async fn send_gps(&mut self, timestamp_us: u64, data: &GpsData, peer_addr: &[u8; 6]) -> Result<()> {
+        sender::send_gps(&mut self.esp_now, timestamp_us, data, peer_addr).await
+    }
+
+    /// Receive sensor data asynchronously (blocking until data arrives)
+    pub async fn receive(&mut self) -> Result<SensorMessage> {
+        receiver::receive(&mut self.esp_now).await
+    }
+
+    /// Add a peer to the peer list
+    ///
+    /// Before sending to a specific peer, you must add them to the peer list.
+    /// Broadcasting does not require adding peers.
+    pub fn add_peer(&mut self, peer_addr: &[u8; 6]) -> Result<()> {
+        let peer_info = PeerInfo {
+            peer_address: *peer_addr,
+            lmk: None,
+            channel: None,
+            interface: EspNowWifiInterface::Station,
+            encrypt: false,
+        };
+        self.esp_now.add_peer(peer_info)?;
+        Ok(())
+    }
+
+    /// Remove a peer from the peer list
+    pub fn remove_peer(&mut self, peer_addr: &[u8; 6]) -> Result<()> {
+        self.esp_now.remove_peer(peer_addr)?;
+        Ok(())
+    }
+
+    /// Check if a peer exists in the peer list
+    pub fn peer_exists(&self, peer_addr: &[u8; 6]) -> bool {
+        self.esp_now.peer_exists(peer_addr)
+    }
+}

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
@@ -54,7 +54,7 @@ impl<'a> AirCommTransceiver<'a> {
         sender::send_gps(&mut self.esp_now, timestamp_us, data, peer_addr).await
     }
 
-    /// Receive sensor data asynchronously (blocking until data arrives)
+    /// Receive sensor data (suspends until data arrives)
     pub async fn receive(&mut self) -> Result<SensorMessage> {
         receiver::receive(&mut self.esp_now).await
     }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -1,0 +1,305 @@
+//! Protocol layer for serialization and deserialization
+//!
+//! This module handles converting sensor data structures to/from byte arrays
+//! for transmission over ESP-NOW. Uses simple binary protocol with message
+//! type header.
+
+use super::message::*;
+use super::error::{AirCommError, Result};
+use crate::types::{GpsData, GpsTime};
+
+/// Maximum payload size for ESP-NOW (250 bytes)
+pub const MAX_PAYLOAD_SIZE: usize = 250;
+
+/// Protocol header size (message type + timestamp)
+pub const HEADER_SIZE: usize = 1 + 8; // message_type(1) + timestamp_us(8) = 9 bytes
+
+/// Serialize heartbeat data into a byte buffer
+///
+/// Format: [MessageType:1][Timestamp:8][Magic:1]
+///
+/// # Arguments
+/// * `timestamp_us` - Sender's timestamp in microseconds
+/// * `data` - Heartbeat data to serialize
+/// * `buffer` - Output buffer (must be at least HEADER_SIZE + HeartbeatData::SERIALIZED_SIZE)
+///
+/// # Returns
+/// Number of bytes written
+pub fn serialize_heartbeat(timestamp_us: u64, data: &HeartbeatData, buffer: &mut [u8]) -> Result<usize> {
+    let required_size = HEADER_SIZE + HeartbeatData::SERIALIZED_SIZE;
+    if buffer.len() < required_size {
+        return Err(AirCommError::BufferTooSmall);
+    }
+
+    let mut offset = 0;
+    
+    // Write message type
+    buffer[offset] = MessageType::Heartbeat.to_u8();
+    offset += 1;
+    
+    // Write timestamp
+    write_u64_le(buffer, offset, timestamp_us);
+    offset += 8;
+    
+    // Write magic byte
+    buffer[offset] = data.magic;
+    offset += 1;
+    
+    Ok(offset)
+}
+
+/// Serialize IMU data into a byte buffer
+///
+/// Format: [MessageType:1][Timestamp:8][ImuData:TBD]
+///
+/// # Arguments
+/// * `timestamp_us` - Sender's timestamp in microseconds
+/// * `data` - IMU data to serialize
+/// * `buffer` - Output buffer (must be at least HEADER_SIZE + IMU_SERIALIZED_SIZE)
+///
+/// # Returns
+/// Number of bytes written
+pub fn serialize_imu(timestamp_us: u64, data: &ImuData, buffer: &mut [u8]) -> Result<usize> {
+    let required_size = HEADER_SIZE + IMU_SERIALIZED_SIZE;
+    if buffer.len() < required_size {
+        return Err(AirCommError::BufferTooSmall);
+    }
+
+    // TODO: Implement serialization
+    // - Write message type
+    // - Write timestamp
+    // - Write IMU data fields in little-endian format
+    
+    todo!("Implement serialize_imu")
+}
+
+/// Serialize GPS data into a byte buffer
+///
+/// Format: [MessageType:1][Timestamp:8][lat:8][lon:8][alt:4][speed:4][heading:2][year:2][month:1][day:1][hours:1][minutes:1][seconds:1][millis:2]
+///
+/// # Arguments
+/// * `timestamp_us` - Sender's timestamp in microseconds
+/// * `data` - GPS data to serialize
+/// * `buffer` - Output buffer (must be at least HEADER_SIZE + GPS_SERIALIZED_SIZE)
+///
+/// # Returns
+/// Number of bytes written
+pub fn serialize_gps(timestamp_us: u64, data: &GpsData, buffer: &mut [u8]) -> Result<usize> {
+    let required_size = HEADER_SIZE + GPS_SERIALIZED_SIZE;
+    if buffer.len() < required_size {
+        return Err(AirCommError::BufferTooSmall);
+    }
+
+    let mut offset = 0;
+    
+    // Write message type
+    buffer[offset] = MessageType::Gps.to_u8();
+    offset += 1;
+    
+    // Write timestamp
+    write_u64_le(buffer, offset, timestamp_us);
+    offset += 8;
+    
+    // Write GPS fields
+    write_f64_le(buffer, offset, data.lat);
+    offset += 8;
+    
+    write_f64_le(buffer, offset, data.lon);
+    offset += 8;
+    
+    write_f32_le(buffer, offset, data.alt);
+    offset += 4;
+    
+    write_f32_le(buffer, offset, data.speed_kts);
+    offset += 4;
+    
+    write_u16_le(buffer, offset, data.heading);
+    offset += 2;
+    
+    // Write GpsTime fields
+    write_u16_le(buffer, offset, data.utc_time.year);
+    offset += 2;
+    
+    buffer[offset] = data.utc_time.month;
+    offset += 1;
+    
+    buffer[offset] = data.utc_time.day;
+    offset += 1;
+    
+    buffer[offset] = data.utc_time.hours;
+    offset += 1;
+    
+    buffer[offset] = data.utc_time.minutes;
+    offset += 1;
+    
+    buffer[offset] = data.utc_time.seconds;
+    offset += 1;
+    
+    write_u16_le(buffer, offset, data.utc_time.millis);
+    offset += 2;
+    
+    Ok(offset)
+}
+
+/// Deserialize received data into a sensor message
+///
+/// Reads the message type header, timestamp, and deserializes the appropriate payload
+///
+/// # Arguments
+/// * `data` - Raw received data
+/// * `src_address` - Source MAC address
+///
+/// # Returns
+/// Parsed sensor message with timestamp and payload
+pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
+    if data.len() < HEADER_SIZE {
+        return Err(AirCommError::InvalidMessage);
+    }
+
+    let msg_type = MessageType::from_u8(data[0])
+        .ok_or(AirCommError::UnknownMessageType)?;
+    
+    // Read timestamp (always at offset 1)
+    let timestamp_us = read_u64_le(data, 1);
+    let payload_offset = 9; // After message type (1) + timestamp (8)
+
+    let payload = match msg_type {
+        MessageType::Imu => {
+            // TODO: Deserialize IMU data
+            todo!("Implement IMU deserialization")
+        }
+        MessageType::Gps => {
+            let required_size = HEADER_SIZE + GPS_SERIALIZED_SIZE;
+            if data.len() < required_size {
+                return Err(AirCommError::InvalidMessage);
+            }
+            
+            let mut offset = payload_offset;
+            
+            // Read GPS fields
+            let lat = read_f64_le(data, offset);
+            offset += 8;
+            
+            let lon = read_f64_le(data, offset);
+            offset += 8;
+            
+            let alt = read_f32_le(data, offset);
+            offset += 4;
+            
+            let speed_kts = read_f32_le(data, offset);
+            offset += 4;
+            
+            let heading = read_u16_le(data, offset);
+            offset += 2;
+            
+            // Read GpsTime fields
+            let year = read_u16_le(data, offset);
+            offset += 2;
+            
+            let month = data[offset];
+            offset += 1;
+            
+            let day = data[offset];
+            offset += 1;
+            
+            let hours = data[offset];
+            offset += 1;
+            
+            let minutes = data[offset];
+            offset += 1;
+            
+            let seconds = data[offset];
+            offset += 1;
+            
+            let millis = read_u16_le(data, offset);
+            
+            SensorPayload::Gps(GpsData {
+                lat,
+                lon,
+                alt,
+                speed_kts,
+                heading,
+                utc_time: GpsTime {
+                    year,
+                    month,
+                    day,
+                    hours,
+                    minutes,
+                    seconds,
+                    millis,
+                },
+            })
+        }
+        MessageType::Heartbeat => {
+            let required_size = HEADER_SIZE + HeartbeatData::SERIALIZED_SIZE;
+            if data.len() < required_size {
+                return Err(AirCommError::InvalidMessage);
+            }
+            
+            let offset = payload_offset;
+            
+            // Read magic byte
+            let magic = data[offset];
+            
+            SensorPayload::Heartbeat(HeartbeatData { magic })
+        }
+    };
+    
+    Ok(SensorMessage {
+        src_address,
+        timestamp_us,
+        payload,
+    })
+}
+
+/// Helper to write f32 in little-endian format
+fn write_f32_le(buffer: &mut [u8], offset: usize, value: f32) {
+    let bytes = value.to_le_bytes();
+    buffer[offset..offset + 4].copy_from_slice(&bytes);
+}
+
+/// Helper to write f64 in little-endian format
+fn write_f64_le(buffer: &mut [u8], offset: usize, value: f64) {
+    let bytes = value.to_le_bytes();
+    buffer[offset..offset + 8].copy_from_slice(&bytes);
+}
+
+/// Helper to write u16 in little-endian format
+fn write_u16_le(buffer: &mut [u8], offset: usize, value: u16) {
+    let bytes = value.to_le_bytes();
+    buffer[offset..offset + 2].copy_from_slice(&bytes);
+}
+
+/// Helper to write u64 in little-endian format
+fn write_u64_le(buffer: &mut [u8], offset: usize, value: u64) {
+    let bytes = value.to_le_bytes();
+    buffer[offset..offset + 8].copy_from_slice(&bytes);
+}
+
+/// Helper to read f32 from little-endian format
+fn read_f32_le(buffer: &[u8], offset: usize) -> f32 {
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&buffer[offset..offset + 4]);
+    f32::from_le_bytes(bytes)
+}
+
+/// Helper to read f64 from little-endian format
+fn read_f64_le(buffer: &[u8], offset: usize) -> f64 {
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&buffer[offset..offset + 8]);
+    f64::from_le_bytes(bytes)
+}
+
+/// Helper to read u16 from little-endian format
+fn read_u16_le(buffer: &[u8], offset: usize) -> u16 {
+    let mut bytes = [0u8; 2];
+    bytes.copy_from_slice(&buffer[offset..offset + 2]);
+    u16::from_le_bytes(bytes)
+}
+
+/// Helper to read u64 from little-endian format
+fn read_u64_le(buffer: &[u8], offset: usize) -> u64 {
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&buffer[offset..offset + 8]);
+    u64::from_le_bytes(bytes)
+}

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -4,6 +4,8 @@
 //! for transmission over ESP-NOW. Uses simple binary protocol with message
 //! type header.
 
+use byteorder::{ByteOrder, LittleEndian};
+
 use super::message::*;
 use super::error::{AirCommError, Result};
 use crate::types::{GpsData, GpsTime};
@@ -38,7 +40,7 @@ pub fn serialize_heartbeat(timestamp_us: u64, data: &HeartbeatData, buffer: &mut
     offset += 1;
     
     // Write timestamp
-    write_u64_le(buffer, offset, timestamp_us);
+    LittleEndian::write_u64(&mut buffer[offset..], timestamp_us);
     offset += 8;
     
     // Write magic byte
@@ -97,27 +99,27 @@ pub fn serialize_gps(timestamp_us: u64, data: &GpsData, buffer: &mut [u8]) -> Re
     offset += 1;
     
     // Write timestamp
-    write_u64_le(buffer, offset, timestamp_us);
+    LittleEndian::write_u64(&mut buffer[offset..], timestamp_us);
     offset += 8;
     
     // Write GPS fields
-    write_f64_le(buffer, offset, data.lat);
+    LittleEndian::write_f64(&mut buffer[offset..], data.lat);
     offset += 8;
     
-    write_f64_le(buffer, offset, data.lon);
+    LittleEndian::write_f64(&mut buffer[offset..], data.lon);
     offset += 8;
     
-    write_f32_le(buffer, offset, data.alt);
+    LittleEndian::write_f32(&mut buffer[offset..], data.alt);
     offset += 4;
     
-    write_f32_le(buffer, offset, data.speed_kts);
+    LittleEndian::write_f32(&mut buffer[offset..], data.speed_kts);
     offset += 4;
     
-    write_u16_le(buffer, offset, data.heading);
+    LittleEndian::write_u16(&mut buffer[offset..], data.heading);
     offset += 2;
     
     // Write GpsTime fields
-    write_u16_le(buffer, offset, data.utc_time.year);
+    LittleEndian::write_u16(&mut buffer[offset..], data.utc_time.year);
     offset += 2;
     
     buffer[offset] = data.utc_time.month;
@@ -135,7 +137,7 @@ pub fn serialize_gps(timestamp_us: u64, data: &GpsData, buffer: &mut [u8]) -> Re
     buffer[offset] = data.utc_time.seconds;
     offset += 1;
     
-    write_u16_le(buffer, offset, data.utc_time.millis);
+    LittleEndian::write_u16(&mut buffer[offset..], data.utc_time.millis);
     offset += 2;
     
     Ok(offset)
@@ -160,89 +162,13 @@ pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
         .ok_or(AirCommError::UnknownMessageType)?;
     
     // Read timestamp (always at offset 1)
-    let timestamp_us = read_u64_le(data, 1);
+    let timestamp_us = LittleEndian::read_u64(&data[1..]);
     let payload_offset = 9; // After message type (1) + timestamp (8)
 
     let payload = match msg_type {
-        MessageType::Imu => {
-            // TODO: Deserialize IMU data
-            todo!("Implement IMU deserialization")
-        }
-        MessageType::Gps => {
-            let required_size = HEADER_SIZE + GPS_SERIALIZED_SIZE;
-            if data.len() < required_size {
-                return Err(AirCommError::InvalidMessage);
-            }
-            
-            let mut offset = payload_offset;
-            
-            // Read GPS fields
-            let lat = read_f64_le(data, offset);
-            offset += 8;
-            
-            let lon = read_f64_le(data, offset);
-            offset += 8;
-            
-            let alt = read_f32_le(data, offset);
-            offset += 4;
-            
-            let speed_kts = read_f32_le(data, offset);
-            offset += 4;
-            
-            let heading = read_u16_le(data, offset);
-            offset += 2;
-            
-            // Read GpsTime fields
-            let year = read_u16_le(data, offset);
-            offset += 2;
-            
-            let month = data[offset];
-            offset += 1;
-            
-            let day = data[offset];
-            offset += 1;
-            
-            let hours = data[offset];
-            offset += 1;
-            
-            let minutes = data[offset];
-            offset += 1;
-            
-            let seconds = data[offset];
-            offset += 1;
-            
-            let millis = read_u16_le(data, offset);
-            
-            SensorPayload::Gps(GpsData {
-                lat,
-                lon,
-                alt,
-                speed_kts,
-                heading,
-                utc_time: GpsTime {
-                    year,
-                    month,
-                    day,
-                    hours,
-                    minutes,
-                    seconds,
-                    millis,
-                },
-            })
-        }
-        MessageType::Heartbeat => {
-            let required_size = HEADER_SIZE + HeartbeatData::SERIALIZED_SIZE;
-            if data.len() < required_size {
-                return Err(AirCommError::InvalidMessage);
-            }
-            
-            let offset = payload_offset;
-            
-            // Read magic byte
-            let magic = data[offset];
-            
-            SensorPayload::Heartbeat(HeartbeatData { magic })
-        }
+        MessageType::Imu => deserialize_imu(data, payload_offset)?,
+        MessageType::Gps => deserialize_gps(data, payload_offset)?,
+        MessageType::Heartbeat => deserialize_heartbeat(data, payload_offset)?,
     };
     
     Ok(SensorMessage {
@@ -252,54 +178,83 @@ pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
     })
 }
 
-/// Helper to write f32 in little-endian format
-fn write_f32_le(buffer: &mut [u8], offset: usize, value: f32) {
-    let bytes = value.to_le_bytes();
-    buffer[offset..offset + 4].copy_from_slice(&bytes);
+/// Deserialize IMU payload from buffer
+fn deserialize_imu(_data: &[u8], _payload_offset: usize) -> Result<SensorPayload> {
+    // TODO: Deserialize IMU data
+    todo!("Implement IMU deserialization")
 }
 
-/// Helper to write f64 in little-endian format
-fn write_f64_le(buffer: &mut [u8], offset: usize, value: f64) {
-    let bytes = value.to_le_bytes();
-    buffer[offset..offset + 8].copy_from_slice(&bytes);
+/// Deserialize GPS payload from buffer
+fn deserialize_gps(data: &[u8], payload_offset: usize) -> Result<SensorPayload> {
+    let required_size = HEADER_SIZE + GPS_SERIALIZED_SIZE;
+    if data.len() < required_size {
+        return Err(AirCommError::InvalidMessage);
+    }
+    
+    let mut offset = payload_offset;
+    
+    // Read GPS fields
+    let lat = LittleEndian::read_f64(&data[offset..]);
+    offset += 8;
+    
+    let lon = LittleEndian::read_f64(&data[offset..]);
+    offset += 8;
+    
+    let alt = LittleEndian::read_f32(&data[offset..]);
+    offset += 4;
+    
+    let speed_kts = LittleEndian::read_f32(&data[offset..]);
+    offset += 4;
+    
+    let heading = LittleEndian::read_u16(&data[offset..]);
+    offset += 2;
+    
+    // Read GpsTime fields
+    let year = LittleEndian::read_u16(&data[offset..]);
+    offset += 2;
+    
+    let month = data[offset];
+    offset += 1;
+    
+    let day = data[offset];
+    offset += 1;
+    
+    let hours = data[offset];
+    offset += 1;
+    
+    let minutes = data[offset];
+    offset += 1;
+    
+    let seconds = data[offset];
+    offset += 1;
+    
+    let millis = LittleEndian::read_u16(&data[offset..]);
+    
+    Ok(SensorPayload::Gps(GpsData {
+        lat,
+        lon,
+        alt,
+        speed_kts,
+        heading,
+        utc_time: GpsTime {
+            year,
+            month,
+            day,
+            hours,
+            minutes,
+            seconds,
+            millis,
+        },
+    }))
 }
 
-/// Helper to write u16 in little-endian format
-fn write_u16_le(buffer: &mut [u8], offset: usize, value: u16) {
-    let bytes = value.to_le_bytes();
-    buffer[offset..offset + 2].copy_from_slice(&bytes);
-}
-
-/// Helper to write u64 in little-endian format
-fn write_u64_le(buffer: &mut [u8], offset: usize, value: u64) {
-    let bytes = value.to_le_bytes();
-    buffer[offset..offset + 8].copy_from_slice(&bytes);
-}
-
-/// Helper to read f32 from little-endian format
-fn read_f32_le(buffer: &[u8], offset: usize) -> f32 {
-    let mut bytes = [0u8; 4];
-    bytes.copy_from_slice(&buffer[offset..offset + 4]);
-    f32::from_le_bytes(bytes)
-}
-
-/// Helper to read f64 from little-endian format
-fn read_f64_le(buffer: &[u8], offset: usize) -> f64 {
-    let mut bytes = [0u8; 8];
-    bytes.copy_from_slice(&buffer[offset..offset + 8]);
-    f64::from_le_bytes(bytes)
-}
-
-/// Helper to read u16 from little-endian format
-fn read_u16_le(buffer: &[u8], offset: usize) -> u16 {
-    let mut bytes = [0u8; 2];
-    bytes.copy_from_slice(&buffer[offset..offset + 2]);
-    u16::from_le_bytes(bytes)
-}
-
-/// Helper to read u64 from little-endian format
-fn read_u64_le(buffer: &[u8], offset: usize) -> u64 {
-    let mut bytes = [0u8; 8];
-    bytes.copy_from_slice(&buffer[offset..offset + 8]);
-    u64::from_le_bytes(bytes)
+/// Deserialize Heartbeat payload from buffer
+fn deserialize_heartbeat(data: &[u8], payload_offset: usize) -> Result<SensorPayload> {
+    let required_size = HEADER_SIZE + HeartbeatData::SERIALIZED_SIZE;
+    if data.len() < required_size {
+        return Err(AirCommError::InvalidMessage);
+    }
+    
+    let magic = data[payload_offset];
+    Ok(SensorPayload::Heartbeat(HeartbeatData { magic }))
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/receiver.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/receiver.rs
@@ -1,0 +1,20 @@
+//! Receiver functions for ESP-NOW data reception
+//!
+//! This module contains the core receiving logic for receiving and parsing
+//! sensor data from ESP-NOW. These functions are called by AirCommTransceiver.
+
+use super::error::Result;
+use super::message::*;
+use super::protocol::*;
+use esp_radio::esp_now::EspNow;
+
+/// Receive and parse sensor message asynchronously
+///
+/// Waits for incoming data and returns the parsed message with timestamp.
+pub(crate) async fn receive(esp_now: &mut EspNow<'_>) -> Result<SensorMessage> {
+    let received_data = esp_now.receive_async().await;
+    let src_address = received_data.info.src_address;
+    let message = deserialize(received_data.data(), src_address)?;
+
+    Ok(message)
+}

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
@@ -1,0 +1,59 @@
+//! Sender functions for ESP-NOW data transmission
+//!
+//! This module contains the core sending logic for transmitting sensor data
+//! over ESP-NOW. These functions are called by AirCommTransceiver.
+
+use super::error::Result;
+use super::message::*;
+use super::protocol::{serialize_gps, serialize_heartbeat, serialize_imu, MAX_PAYLOAD_SIZE};
+use esp_radio::esp_now::EspNow;
+
+/// Broadcast MAC address for sending to all peers
+pub const BROADCAST: [u8; 6] = [0xFF; 6];
+
+/// Send heartbeat message asynchronously
+pub(crate) async fn send_heartbeat(
+    esp_now: &mut EspNow<'_>,
+    timestamp_us: u64,
+    data: &HeartbeatData,
+    peer_addr: &[u8; 6],
+) -> Result<()> {
+    let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
+    let size = serialize_heartbeat(timestamp_us, data, &mut buffer)?;
+
+    esp_now.send_async(peer_addr, &buffer[..size]).await?;
+
+    Ok(())
+}
+
+/// Send IMU data asynchronously
+#[allow(dead_code)]
+pub(crate) async fn send_imu(
+    esp_now: &mut EspNow<'_>,
+    timestamp_us: u64,
+    data: &ImuData,
+    peer_addr: &[u8; 6],
+) -> Result<()> {
+    let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
+    let size = serialize_imu(timestamp_us, data, &mut buffer)?;
+
+    esp_now.send_async(peer_addr, &buffer[..size]).await?;
+
+    Ok(())
+}
+
+/// Send GPS data asynchronously
+#[allow(dead_code)]
+pub(crate) async fn send_gps(
+    esp_now: &mut EspNow<'_>,
+    timestamp_us: u64,
+    data: &GpsData,
+    peer_addr: &[u8; 6],
+) -> Result<()> {
+    let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
+    let size = serialize_gps(timestamp_us, data, &mut buffer)?;
+
+    esp_now.send_async(peer_addr, &buffer[..size]).await?;
+
+    Ok(())
+}

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -41,12 +41,12 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
         .expect("GPS task did not spawn");
 
     // ESP-NOW / AirComm task
-    if let Some(esp_now) = board.take_esp_now() {
-        match AirCommTransceiver::new(esp_now) {
+    if let Some(wifi) = board.take_wifi() {
+        match AirCommTransceiver::new(wifi.esp_now) {
             Ok(transceiver) => {
                 info!("AirComm transceiver initialized");
                 spawner
-                    .spawn(espnow_task(transceiver))
+                    .spawn(espnow_task(transceiver, wifi.controller))
                     .expect("ESP-NOW task did not spawn");
             }
             Err(e) => {
@@ -54,7 +54,7 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
             }
         }
     } else {
-        warn!("ESP-NOW not available - skipping wireless communication");
+        warn!("WiFi not available - skipping wireless communication");
     }
 
     loop {
@@ -87,8 +87,13 @@ async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Asy
 ///
 /// Handles both sending heartbeats at regular intervals and receiving messages.
 /// Uses timeout-based receive to avoid blocking heartbeat transmission.
+///
+/// Note: `_wifi_controller` must be kept alive for ESP-NOW to function properly.
 #[embassy_executor::task]
-async fn espnow_task(mut transceiver: AirCommTransceiver<'static>) {
+async fn espnow_task(
+    mut transceiver: AirCommTransceiver<'static>,
+    _wifi_controller: esp_radio::wifi::WifiController<'static>,
+) {
     info!("[ESP-NOW] Task started");
 
     const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -1,10 +1,13 @@
-use esp_hal::gpio::Output;
 /// app.rs
 /// responsible for starting the "app" and setting any necessary configs
+
+use embassy_time::{Duration, Instant};
+use esp_hal::gpio::Output;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
+use crate::aircomm::{AirCommTransceiver, HeartbeatData, SensorMessage, SensorPayload, BROADCAST};
 use crate::gps::{init_gps, start_gps};
 use crate::hmi::{neopixel, start_hmi};
 use crate::imu::start_imu;
@@ -37,6 +40,23 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
         .spawn(start_gps_task(gps2_uart))
         .expect("GPS task did not spawn");
 
+    // ESP-NOW / AirComm task
+    if let Some(esp_now) = board.take_esp_now() {
+        match AirCommTransceiver::new(esp_now) {
+            Ok(transceiver) => {
+                info!("AirComm transceiver initialized");
+                spawner
+                    .spawn(espnow_task(transceiver))
+                    .expect("ESP-NOW task did not spawn");
+            }
+            Err(e) => {
+                warn!("Failed to create AirComm transceiver: {:?}", e);
+            }
+        }
+    } else {
+        warn!("ESP-NOW not available - skipping wireless communication");
+    }
+
     loop {
         embassy_time::Timer::after_secs(1).await
     }
@@ -52,7 +72,7 @@ async fn start_hmi_task(user_led: Output<'static>, neopixel: neopixel::NeoPixel<
 }
 
 #[embassy_executor::task]
-async fn start_imu_task(mut imu_spi_device: SharedSpiDevice) {
+async fn start_imu_task(imu_spi_device: SharedSpiDevice) {
     info!("IMU TASK BEING SPAWNED");
     start_imu(imu_spi_device).await;
 }
@@ -61,4 +81,93 @@ async fn start_imu_task(mut imu_spi_device: SharedSpiDevice) {
 async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Async>) {
     gps2_uart = init_gps(gps2_uart).await;
     start_gps(gps2_uart).await;
+}
+
+/// ESP-NOW transceiver task
+///
+/// Handles both sending heartbeats at regular intervals and receiving messages.
+/// Uses timeout-based receive to avoid blocking heartbeat transmission.
+#[embassy_executor::task]
+async fn espnow_task(mut transceiver: AirCommTransceiver<'static>) {
+    info!("[ESP-NOW] Task started");
+
+    const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+
+    // Send first heartbeat immediately
+    send_heartbeat(&mut transceiver).await;
+    let mut last_heartbeat = Instant::now();
+
+    loop {
+        // Calculate how long until next heartbeat is due
+        let elapsed = last_heartbeat.elapsed();
+        let timeout = if elapsed >= HEARTBEAT_INTERVAL {
+            Duration::from_millis(0)
+        } else {
+            HEARTBEAT_INTERVAL - elapsed
+        };
+
+        // Try to receive with timeout (doesn't cancel the receive, just times out)
+        match embassy_time::with_timeout(timeout, transceiver.receive()).await {
+            Ok(Ok(msg)) => {
+                // Successfully received a message
+                handle_received_message(&msg);
+            }
+            Ok(Err(e)) => {
+                // Receive error
+                warn!("[ESP-NOW RX] Error: {:?}", e);
+            }
+            Err(_) => {
+                // Timeout - no message received, that's fine
+            }
+        }
+
+        // Check if it's time to send heartbeat
+        if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
+            send_heartbeat(&mut transceiver).await;
+            last_heartbeat = Instant::now();
+        }
+    }
+}
+
+async fn send_heartbeat(transceiver: &mut AirCommTransceiver<'static>) {
+    let timestamp_us = Instant::now().as_micros();
+    let heartbeat = HeartbeatData::default();
+
+    match transceiver.send_heartbeat(timestamp_us, &heartbeat, &BROADCAST).await {
+        Ok(()) => {
+            info!("[ESP-NOW TX] Heartbeat sent (time={}us)", timestamp_us);
+        }
+        Err(e) => {
+            warn!("[ESP-NOW TX] Send failed: {:?}", e);
+        }
+    }
+}
+
+fn handle_received_message(msg: &SensorMessage) {
+    let src = msg.src_address;
+    let timestamp = msg.timestamp_us;
+    
+    match &msg.payload {
+        SensorPayload::Heartbeat(data) => {
+            info!(
+                "[ESP-NOW RX] Heartbeat from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | magic=0x{:02X}, time={}us",
+                src[0], src[1], src[2], src[3], src[4], src[5],
+                data.magic, timestamp
+            );
+        }
+        SensorPayload::Imu(_data) => {
+            info!(
+                "[ESP-NOW RX] IMU from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | time={}us, TODO: IMU fields",
+                src[0], src[1], src[2], src[3], src[4], src[5],
+                timestamp
+            );
+        }
+        SensorPayload::Gps(data) => {
+            info!(
+                "[ESP-NOW RX] GPS from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | time={}us, lat={:.6}, lon={:.6}",
+                src[0], src[1], src[2], src[3], src[4], src[5],
+                timestamp, data.lat, data.lon
+            );
+        }
+    }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -1,46 +1,75 @@
 /// app.rs
 /// responsible for starting the "app" and setting any necessary configs
 
-use embassy_time::{Duration, Instant};
+#[cfg(feature = "wifi")]
+use embassy_time::Duration;
+#[cfg(feature = "wifi")]
+use embassy_time::Instant;
+#[cfg(feature = "hmi")]
 use esp_hal::gpio::Output;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
+#[cfg(feature = "wifi")]
 use crate::aircomm::{AirCommTransceiver, HeartbeatData, SensorMessage, SensorPayload, BROADCAST};
+#[cfg(feature = "gps")]
 use crate::gps::{init_gps, start_gps};
+#[cfg(feature = "hmi")]
 use crate::hmi::{neopixel, start_hmi};
+#[cfg(feature = "imu")]
 use crate::imu::start_imu;
-use crate::{BoardPeripherals, SharedSpiDevice};
+use crate::BoardPeripherals;
+#[cfg(feature = "imu")]
+use crate::SharedSpiDevice;
 
 pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mut board: B) {
     info!("app is starting execution now");
 
+    #[cfg(feature = "hmi")]
     let user_led = board.take_user_led();
+    #[cfg(feature = "hmi")]
     trace!("User Led initialized!");
+    
+    #[cfg(feature = "hmi")]
     let neopixel = board.take_neopixel();
+    #[cfg(feature = "hmi")]
     trace!("NeoPixel initialized!");
+    
+    #[cfg(feature = "hmi")]
     let _disp_spi_device = board.take_disp_spi_device();
+    #[cfg(feature = "hmi")]
     trace!("DISPLAY_SPI device taken");
+    
+    #[cfg(feature = "imu")]
     let imu_spi_device = board.take_imu_spi_device();
+    #[cfg(feature = "imu")]
     trace!("IMU_SPI device taken");
+    
+    #[cfg(feature = "gps")]
     let gps2_uart = board.take_gps2_uart();
+    #[cfg(feature = "gps")]
     trace!("Gps2_Uart initialized!");
 
     info!("all periphs taken");
 
+    #[cfg(feature = "hmi")]
     spawner
         .spawn(start_hmi_task(user_led, neopixel))
         .expect("HMI task did not spawn");
 
+    #[cfg(feature = "imu")]
     spawner
         .spawn(start_imu_task(imu_spi_device))
         .expect("imu task did not spawn");
+    
+    #[cfg(feature = "gps")]
     spawner
         .spawn(start_gps_task(gps2_uart))
         .expect("GPS task did not spawn");
 
     // ESP-NOW / AirComm task
+    #[cfg(feature = "wifi")]
     if let Some(wifi) = board.take_wifi() {
         match AirCommTransceiver::new(wifi.esp_now) {
             Ok(transceiver) => {
@@ -62,6 +91,7 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
     }
 }
 
+#[cfg(feature = "hmi")]
 #[embassy_executor::task]
 async fn start_hmi_task(user_led: Output<'static>, neopixel: neopixel::NeoPixel<'static>) {
     // Task configuration
@@ -71,12 +101,14 @@ async fn start_hmi_task(user_led: Output<'static>, neopixel: neopixel::NeoPixel<
     start_hmi(user_led, led_rate_hz, neopixel, neopixel_brightness).await;
 }
 
+#[cfg(feature = "imu")]
 #[embassy_executor::task]
 async fn start_imu_task(imu_spi_device: SharedSpiDevice) {
     info!("IMU TASK BEING SPAWNED");
     start_imu(imu_spi_device).await;
 }
 
+#[cfg(feature = "gps")]
 #[embassy_executor::task]
 async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Async>) {
     gps2_uart = init_gps(gps2_uart).await;
@@ -89,6 +121,7 @@ async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Asy
 /// Uses timeout-based receive to avoid blocking heartbeat transmission.
 ///
 /// Note: `_wifi_controller` must be kept alive for ESP-NOW to function properly.
+#[cfg(feature = "wifi")]
 #[embassy_executor::task]
 async fn espnow_task(
     mut transceiver: AirCommTransceiver<'static>,
@@ -134,6 +167,7 @@ async fn espnow_task(
     }
 }
 
+#[cfg(feature = "wifi")]
 async fn send_heartbeat(transceiver: &mut AirCommTransceiver<'static>) {
     let timestamp_us = Instant::now().as_micros();
     let heartbeat = HeartbeatData::default();
@@ -148,6 +182,7 @@ async fn send_heartbeat(transceiver: &mut AirCommTransceiver<'static>) {
     }
 }
 
+#[cfg(feature = "wifi")]
 fn handle_received_message(msg: &SensorMessage) {
     let src = msg.src_address;
     let timestamp = msg.timestamp_us;

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -45,9 +45,13 @@ pub struct DevkitC {
     pub user_led: Option<esp_hal::gpio::Output<'static>>,
     pub neopixel: Option<neopixel::NeoPixel<'static>>,
     pub disp_spi: Option<SharedSpiDevice>,
-
     pub imu_spi: Option<SharedSpiDevice>,
     pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Async>>,
+    // ESP-NOW / AirComm
+    pub esp_now: Option<esp_radio::esp_now::EspNow<'static>>,
+    #[allow(dead_code)]
+    pub wifi_controller: Option<esp_radio::wifi::WifiController<'static>>,
+    pub wifi_peripheral: Option<esp_hal::peripherals::WIFI<'static>>,
 }
 
 impl DevkitC {
@@ -99,12 +103,49 @@ impl DevkitC {
         );
         let imu_spi_device = SpiDevice::new(spi_bus, imu_spi2_cs);
         let disp_spi_device = SpiDevice::new(spi_bus, disp_spi2_cs);
+
+        // DO NOT initialize ESP-NOW here! It will deadlock.
+        // WiFi initialization will be done later in async context (main)
+
         Self {
             user_led: Some(user_led),
             neopixel: Some(neopixel),
             disp_spi: Some(disp_spi_device),
             imu_spi: Some(imu_spi_device),
             gps2_uart: Some(gps2_uart),
+            esp_now: None,
+            wifi_controller: None,
+            wifi_peripheral: Some(peripherals.WIFI),
+        }
+    }
+
+    /// Initialize ESP-NOW in an async context (must be called after RTOS tasks are running)
+    pub async fn init_esp_now(&mut self) {
+        if let Some(wifi_peripheral) = self.wifi_peripheral.take() {
+            info!("Initializing ESP-NOW in async context...");
+
+            // Small delay to ensure RTOS tasks are running
+            embassy_time::Timer::after_millis(200).await;
+
+            match esp_radio::wifi::new(wifi_peripheral, esp_radio::wifi::Config::default()) {
+                Ok((mut wifi_controller, interfaces)) => {
+                    info!("ESP-NOW initialized successfully");
+                    if let Err(e) = wifi_controller.set_mode(esp_radio::wifi::WifiMode::Station) {
+                        warn!("Failed to set WiFi mode: {:?}", e);
+                        return;
+                    }
+                    if let Err(e) = wifi_controller.start() {
+                        warn!("Failed to start WiFi controller: {:?}", e);
+                        return;
+                    }
+
+                    self.wifi_controller = Some(wifi_controller);
+                    self.esp_now = Some(interfaces.esp_now);
+                }
+                Err(e) => {
+                    warn!("WiFi initialization failed: {:?}", e);
+                }
+            }
         }
     }
 }
@@ -136,6 +177,11 @@ impl BoardPeripherals for DevkitC {
         trace!("gps2_uart take called");
         self.gps2_uart.take().expect("gps2_uart already taken")
     }
+
+    fn take_esp_now(&mut self) -> Option<esp_radio::esp_now::EspNow<'static>> {
+        trace!("esp_now take called");
+        self.esp_now.take()
+    }
 }
 
 #[esp_rtos::main]
@@ -147,7 +193,12 @@ async fn main(spawner: embassy_executor::Spawner) {
     let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    app_run(spawner, DevkitC::from_peripherals(peripherals)).await;
+    let mut board = DevkitC::from_peripherals(peripherals);
+
+    // Initialize ESP-NOW in async context (after RTOS scheduler is running)
+    board.init_esp_now().await;
+
+    app_run(spawner, board).await;
     loop {
         embassy_time::Timer::after_secs(1).await
     }

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -6,18 +6,26 @@
     holding buffers for the duration of a data transfer."
 )]
 
+#[cfg(any(feature = "hmi", feature = "imu"))]
 use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
+#[cfg(any(feature = "hmi", feature = "imu"))]
 use embassy_sync::mutex::Mutex;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
+#[cfg(any(feature = "hmi", feature = "imu"))]
 use static_cell::StaticCell;
 
 use esp_alloc as _;
 
-use sensor_board_rev1_test::{
-    BoardPeripherals, SharedSpiBus, SharedSpiDevice, WifiResources, app::app_run, hmi::neopixel,
-};
+#[cfg(feature = "hmi")]
+use sensor_board_rev1_test::hmi::neopixel;
+#[cfg(any(feature = "hmi", feature = "imu"))]
+use sensor_board_rev1_test::{SharedSpiBus, SharedSpiDevice};
+#[cfg(feature = "wifi")]
+use sensor_board_rev1_test::WifiResources;
+use sensor_board_rev1_test::{BoardPeripherals, app::app_run};
 
+#[cfg(any(feature = "hmi", feature = "imu"))]
 static SPI_BUS: StaticCell<SharedSpiBus> = StaticCell::new();
 
 #[panic_handler]
@@ -42,12 +50,17 @@ fn init_heap() {
 }
 
 pub struct DevkitC {
+    #[cfg(feature = "hmi")]
     pub user_led: Option<esp_hal::gpio::Output<'static>>,
+    #[cfg(feature = "hmi")]
     pub neopixel: Option<neopixel::NeoPixel<'static>>,
+    #[cfg(feature = "hmi")]
     pub disp_spi: Option<SharedSpiDevice>,
+    #[cfg(feature = "imu")]
     pub imu_spi: Option<SharedSpiDevice>,
+    #[cfg(feature = "gps")]
     pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Async>>,
-    // WiFi resources (controller + ESP-NOW)
+    #[cfg(feature = "wifi")]
     pub wifi: Option<WifiResources>,
 }
 
@@ -60,48 +73,70 @@ impl DevkitC {
 
         esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
+        // HMI peripherals
+        #[cfg(feature = "hmi")]
         let user_led = esp_hal::gpio::Output::new(
             peripherals.GPIO19,
             esp_hal::gpio::Level::High,
             esp_hal::gpio::OutputConfig::default(),
         );
 
-        let rmt = esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80))
-            .unwrap()
-            .into_async();
-        let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO8);
+        #[cfg(feature = "hmi")]
+        let neopixel = {
+            let rmt = esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80))
+                .unwrap()
+                .into_async();
+            neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO8)
+        };
 
-        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(9600);
-        let gps2_uart = esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
-            .unwrap()
-            .with_rx(peripherals.GPIO23)
-            .with_tx(peripherals.GPIO22)
-            .into_async();
+        // GPS peripheral
+        #[cfg(feature = "gps")]
+        let gps2_uart = {
+            let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(9600);
+            esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
+                .unwrap()
+                .with_rx(peripherals.GPIO23)
+                .with_tx(peripherals.GPIO22)
+                .into_async()
+        };
 
-        let spi_config = esp_hal::spi::master::Config::default()
-            .with_frequency(esp_hal::time::Rate::from_khz(100))
-            .with_mode(esp_hal::spi::Mode::_0);
-        let spi2 = esp_hal::spi::master::Spi::new(peripherals.SPI2, spi_config)
-            .unwrap()
-            .with_sck(peripherals.GPIO6)
-            .with_mosi(peripherals.GPIO7)
-            .with_miso(peripherals.GPIO0)
-            .into_async();
-        let spi_bus = SPI_BUS.init(Mutex::new(spi2));
-        let imu_spi2_cs = esp_hal::gpio::Output::new(
-            peripherals.GPIO1,
-            esp_hal::gpio::Level::High,
-            esp_hal::gpio::OutputConfig::default(),
-        );
-        let disp_spi2_cs = esp_hal::gpio::Output::new(
-            peripherals.GPIO10,
-            esp_hal::gpio::Level::High,
-            esp_hal::gpio::OutputConfig::default(),
-        );
-        let imu_spi_device = SpiDevice::new(spi_bus, imu_spi2_cs);
-        let disp_spi_device = SpiDevice::new(spi_bus, disp_spi2_cs);
+        // SPI bus (shared by HMI display and IMU)
+        #[cfg(any(feature = "hmi", feature = "imu"))]
+        let spi_bus = {
+            let spi_config = esp_hal::spi::master::Config::default()
+                .with_frequency(esp_hal::time::Rate::from_khz(100))
+                .with_mode(esp_hal::spi::Mode::_0);
+            let spi2 = esp_hal::spi::master::Spi::new(peripherals.SPI2, spi_config)
+                .unwrap()
+                .with_sck(peripherals.GPIO6)
+                .with_mosi(peripherals.GPIO7)
+                .with_miso(peripherals.GPIO0)
+                .into_async();
+            SPI_BUS.init(Mutex::new(spi2))
+        };
 
-        // Initialize WiFi (RTOS is already started above)
+        #[cfg(feature = "imu")]
+        let imu_spi_device = {
+            let imu_spi2_cs = esp_hal::gpio::Output::new(
+                peripherals.GPIO1,
+                esp_hal::gpio::Level::High,
+                esp_hal::gpio::OutputConfig::default(),
+            );
+            SpiDevice::new(spi_bus, imu_spi2_cs)
+        };
+
+        #[cfg(feature = "hmi")]
+        let disp_spi_device = {
+            let disp_spi2_cs = esp_hal::gpio::Output::new(
+                peripherals.GPIO10,
+                esp_hal::gpio::Level::High,
+                esp_hal::gpio::OutputConfig::default(),
+            );
+            SpiDevice::new(spi_bus, disp_spi2_cs)
+        };
+
+        // WiFi initialization
+        #[cfg(feature = "wifi")]
         let wifi = match esp_radio::wifi::new(peripherals.WIFI, esp_radio::wifi::Config::default())
         {
             Ok((mut wifi_controller, interfaces)) => {
@@ -126,27 +161,36 @@ impl DevkitC {
         };
 
         Self {
+            #[cfg(feature = "hmi")]
             user_led: Some(user_led),
+            #[cfg(feature = "hmi")]
             neopixel: Some(neopixel),
+            #[cfg(feature = "hmi")]
             disp_spi: Some(disp_spi_device),
+            #[cfg(feature = "imu")]
             imu_spi: Some(imu_spi_device),
+            #[cfg(feature = "gps")]
             gps2_uart: Some(gps2_uart),
+            #[cfg(feature = "wifi")]
             wifi,
         }
     }
 }
 
 impl BoardPeripherals for DevkitC {
+    #[cfg(feature = "hmi")]
     fn take_user_led(&mut self) -> esp_hal::gpio::Output<'static> {
         trace!("user led take called");
         self.user_led.take().expect("user LED already taken")
     }
 
+    #[cfg(feature = "hmi")]
     fn take_neopixel(&mut self) -> neopixel::NeoPixel<'static> {
         trace!("neopixel take called");
         self.neopixel.take().expect("NeoPixel already taken")
     }
 
+    #[cfg(feature = "hmi")]
     fn take_disp_spi_device(&mut self) -> SharedSpiDevice {
         trace!("disp_spi_device take called");
         self.disp_spi
@@ -154,16 +198,19 @@ impl BoardPeripherals for DevkitC {
             .expect("DisplaySPI device already taken")
     }
 
+    #[cfg(feature = "imu")]
     fn take_imu_spi_device(&mut self) -> SharedSpiDevice {
         trace!("imu_spi_device take called");
         self.imu_spi.take().expect("ImuSPI device already taken")
     }
 
+    #[cfg(feature = "gps")]
     fn take_gps2_uart(&mut self) -> esp_hal::uart::Uart<'static, esp_hal::Async> {
         trace!("gps2_uart take called");
         self.gps2_uart.take().expect("gps2_uart already taken")
     }
 
+    #[cfg(feature = "wifi")]
     fn take_wifi(&mut self) -> Option<WifiResources> {
         trace!("wifi take called");
         self.wifi.take()

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -15,7 +15,7 @@ use static_cell::StaticCell;
 use esp_alloc as _;
 
 use sensor_board_rev1_test::{
-    BoardPeripherals, SharedSpiBus, SharedSpiDevice, app::app_run, hmi::neopixel,
+    BoardPeripherals, SharedSpiBus, SharedSpiDevice, WifiResources, app::app_run, hmi::neopixel,
 };
 
 static SPI_BUS: StaticCell<SharedSpiBus> = StaticCell::new();
@@ -47,11 +47,8 @@ pub struct DevkitC {
     pub disp_spi: Option<SharedSpiDevice>,
     pub imu_spi: Option<SharedSpiDevice>,
     pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Async>>,
-    // ESP-NOW / AirComm
-    pub esp_now: Option<esp_radio::esp_now::EspNow<'static>>,
-    #[allow(dead_code)]
-    pub wifi_controller: Option<esp_radio::wifi::WifiController<'static>>,
-    pub wifi_peripheral: Option<esp_hal::peripherals::WIFI<'static>>,
+    // WiFi resources (controller + ESP-NOW)
+    pub wifi: Option<WifiResources>,
 }
 
 impl DevkitC {
@@ -104,8 +101,29 @@ impl DevkitC {
         let imu_spi_device = SpiDevice::new(spi_bus, imu_spi2_cs);
         let disp_spi_device = SpiDevice::new(spi_bus, disp_spi2_cs);
 
-        // DO NOT initialize ESP-NOW here! It will deadlock.
-        // WiFi initialization will be done later in async context (main)
+        // Initialize WiFi (RTOS is already started above)
+        let wifi = match esp_radio::wifi::new(peripherals.WIFI, esp_radio::wifi::Config::default())
+        {
+            Ok((mut wifi_controller, interfaces)) => {
+                info!("WiFi initialized successfully");
+                if let Err(e) = wifi_controller.set_mode(esp_radio::wifi::WifiMode::Station) {
+                    warn!("Failed to set WiFi mode: {:?}", e);
+                    None
+                } else if let Err(e) = wifi_controller.start() {
+                    warn!("Failed to start WiFi controller: {:?}", e);
+                    None
+                } else {
+                    Some(WifiResources {
+                        controller: wifi_controller,
+                        esp_now: interfaces.esp_now,
+                    })
+                }
+            }
+            Err(e) => {
+                warn!("WiFi initialization failed: {:?}", e);
+                None
+            }
+        };
 
         Self {
             user_led: Some(user_led),
@@ -113,39 +131,7 @@ impl DevkitC {
             disp_spi: Some(disp_spi_device),
             imu_spi: Some(imu_spi_device),
             gps2_uart: Some(gps2_uart),
-            esp_now: None,
-            wifi_controller: None,
-            wifi_peripheral: Some(peripherals.WIFI),
-        }
-    }
-
-    /// Initialize ESP-NOW in an async context (must be called after RTOS tasks are running)
-    pub async fn init_esp_now(&mut self) {
-        if let Some(wifi_peripheral) = self.wifi_peripheral.take() {
-            info!("Initializing ESP-NOW in async context...");
-
-            // Small delay to ensure RTOS tasks are running
-            embassy_time::Timer::after_millis(200).await;
-
-            match esp_radio::wifi::new(wifi_peripheral, esp_radio::wifi::Config::default()) {
-                Ok((mut wifi_controller, interfaces)) => {
-                    info!("ESP-NOW initialized successfully");
-                    if let Err(e) = wifi_controller.set_mode(esp_radio::wifi::WifiMode::Station) {
-                        warn!("Failed to set WiFi mode: {:?}", e);
-                        return;
-                    }
-                    if let Err(e) = wifi_controller.start() {
-                        warn!("Failed to start WiFi controller: {:?}", e);
-                        return;
-                    }
-
-                    self.wifi_controller = Some(wifi_controller);
-                    self.esp_now = Some(interfaces.esp_now);
-                }
-                Err(e) => {
-                    warn!("WiFi initialization failed: {:?}", e);
-                }
-            }
+            wifi,
         }
     }
 }
@@ -178,9 +164,9 @@ impl BoardPeripherals for DevkitC {
         self.gps2_uart.take().expect("gps2_uart already taken")
     }
 
-    fn take_esp_now(&mut self) -> Option<esp_radio::esp_now::EspNow<'static>> {
-        trace!("esp_now take called");
-        self.esp_now.take()
+    fn take_wifi(&mut self) -> Option<WifiResources> {
+        trace!("wifi take called");
+        self.wifi.take()
     }
 }
 
@@ -193,10 +179,7 @@ async fn main(spawner: embassy_executor::Spawner) {
     let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    let mut board = DevkitC::from_peripherals(peripherals);
-
-    // Initialize ESP-NOW in async context (after RTOS scheduler is running)
-    board.init_esp_now().await;
+    let board = DevkitC::from_peripherals(peripherals);
 
     app_run(spawner, board).await;
     loop {

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+#[cfg(feature = "hmi")]
 use crate::hmi::neopixel::NeoPixel;
 use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
@@ -7,13 +8,18 @@ use embassy_sync::mutex::Mutex;
 use esp_hal::Async;
 use esp_hal::gpio::Output;
 use esp_hal::spi::master::Spi;
+#[cfg(feature = "gps")]
 use esp_hal::uart::Uart;
 
+#[cfg(feature = "wifi")]
 pub mod aircomm;
 pub mod app;
 pub mod asm330;
+#[cfg(feature = "gps")]
 pub mod gps;
+#[cfg(feature = "hmi")]
 pub mod hmi;
+#[cfg(feature = "imu")]
 pub mod imu;
 pub mod old_asm330;
 pub mod types;
@@ -23,6 +29,7 @@ pub type SharedSpiBus = Mutex<NoopRawMutex, Spi<'static, Async>>;
 pub type SharedSpiDevice = SpiDevice<'static, NoopRawMutex, Spi<'static, Async>, Output<'static>>;
 
 /// WiFi resources bundle containing the controller and available interfaces
+#[cfg(feature = "wifi")]
 pub struct WifiResources {
     /// WiFi controller (manages the WiFi hardware)
     pub controller: esp_radio::wifi::WifiController<'static>,
@@ -32,14 +39,20 @@ pub struct WifiResources {
 
 pub trait BoardPeripherals {
     // HMI
+    #[cfg(feature = "hmi")]
     fn take_user_led(&mut self) -> Output<'static>;
+    #[cfg(feature = "hmi")]
     fn take_neopixel(&mut self) -> NeoPixel<'static>;
+    #[cfg(feature = "hmi")]
     fn take_disp_spi_device(&mut self) -> SharedSpiDevice;
 
     // SENSORS
+    #[cfg(feature = "imu")]
     fn take_imu_spi_device(&mut self) -> SharedSpiDevice;
+    #[cfg(feature = "gps")]
     fn take_gps2_uart(&mut self) -> Uart<'static, Async>;
 
     // WIRELESS
+    #[cfg(feature = "wifi")]
     fn take_wifi(&mut self) -> Option<WifiResources>;
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -9,6 +9,7 @@ use esp_hal::gpio::Output;
 use esp_hal::spi::master::Spi;
 use esp_hal::uart::Uart;
 
+pub mod aircomm;
 pub mod app;
 pub mod asm330;
 pub mod gps;
@@ -30,4 +31,7 @@ pub trait BoardPeripherals {
     // SENSORS
     fn take_imu_spi_device(&mut self) -> SharedSpiDevice;
     fn take_gps2_uart(&mut self) -> Uart<'static, Async>;
+
+    // WIRELESS
+    fn take_esp_now(&mut self) -> Option<esp_radio::esp_now::EspNow<'static>>;
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -22,6 +22,14 @@ pub type SharedSpiBus = Mutex<NoopRawMutex, Spi<'static, Async>>;
 
 pub type SharedSpiDevice = SpiDevice<'static, NoopRawMutex, Spi<'static, Async>, Output<'static>>;
 
+/// WiFi resources bundle containing the controller and available interfaces
+pub struct WifiResources {
+    /// WiFi controller (manages the WiFi hardware)
+    pub controller: esp_radio::wifi::WifiController<'static>,
+    /// ESP-NOW interface for peer-to-peer communication
+    pub esp_now: esp_radio::esp_now::EspNow<'static>,
+}
+
 pub trait BoardPeripherals {
     // HMI
     fn take_user_led(&mut self) -> Output<'static>;
@@ -33,5 +41,5 @@ pub trait BoardPeripherals {
     fn take_gps2_uart(&mut self) -> Uart<'static, Async>;
 
     // WIRELESS
-    fn take_esp_now(&mut self) -> Option<esp_radio::esp_now::EspNow<'static>>;
+    fn take_wifi(&mut self) -> Option<WifiResources>;
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/types.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/types.rs
@@ -1,6 +1,14 @@
 /// types.rs
 /// Defines all of the common datatypes (IMU/GPS/FUSE/etc)
 
+/// IMU sensor data structure
+#[derive(Debug, Clone, Copy)]
+pub struct ImuData {
+    // TODO: IMU data fields
+}
+
+/// GPS timestamp
+#[derive(Debug, Clone, Copy)]
 pub struct GpsTime {
     pub year: u16,
     pub month: u8,
@@ -11,6 +19,8 @@ pub struct GpsTime {
     pub millis: u16,
 }
 
+/// GPS sensor data structure
+#[derive(Debug, Clone, Copy)]
 pub struct GpsData {
     pub lat: f64,
     pub lon: f64,


### PR DESCRIPTION
- Created a big esp-now wrapper under the /aricomm
- Added esp-now task that sends heartbeat message once per second (for no particular reason), and hearing all supported messages
- It works really similar to how the CAN bus communication system was working before, but it wireless and has so much potential

Here is how the console looks like when two esp boards is flashed with this new firmware
<img width="534" height="385" alt="image" src="https://github.com/user-attachments/assets/277e15e5-7a94-47ff-9dd2-304fd579417a" />
