### PR TITLE
Add sensor data flow via ESP-NOW with board-specific modes

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -3,7 +3,7 @@ edition      = "2024"
 name         = "sensor_board_rev1_test"
 rust-version = "1.88"
 version      = "0.1.0"
-default-run  = "sensor_board_rev1_test"
+default-run  = "rev1_board"
 
 [features]
 default = ["hmi", "imu", "gps", "wifi"]
@@ -13,7 +13,8 @@ gps = []      # GPS sensor (UART)
 wifi = []     # WiFi/ESP-NOW wireless communication
 
 [[bin]]
-name = "sensor_board_rev1_test"
+# A shorter name
+name = "rev1_board"
 path = "./src/bin/sensorboard_rev1.rs"
 
 [[bin]]

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
@@ -66,8 +66,8 @@ impl HeartbeatData {
 // Serialization sizes for aircomm protocol (payload only, excluding header)
 // Header is always: message_type(1) + timestamp(8) = 9 bytes
 // HeartbeatData: magic(1) = 1 byte (timestamp moved to message level)
-// ImuData: TBD (timestamp moved to message level)
-pub const IMU_SERIALIZED_SIZE: usize = 0; // TODO: Update when IMU fields are implemented
+// ImuData: accel_x(4) + accel_y(4) + accel_z(4) + gyro_x(4) + gyro_y(4) + gyro_z(4) = 24 bytes
+pub const IMU_SERIALIZED_SIZE: usize = 6 * 4; // 6 f32 fields = 24 bytes
 // GpsTime: year(2) + month(1) + day(1) + hours(1) + minutes(1) + seconds(1) + millis(2) = 9 bytes
 pub const GPS_TIME_SERIALIZED_SIZE: usize = 2 + 1 + 1 + 1 + 1 + 1 + 2;
 // GpsData: lat(8) + lon(8) + alt(4) + speed(4) + heading(2) + time(9) = 35 bytes

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
@@ -43,13 +43,11 @@ impl<'a> AirCommTransceiver<'a> {
     }
 
     /// Send IMU data to a peer
-    #[allow(dead_code)]
     pub async fn send_imu(&mut self, timestamp_us: u64, data: &ImuData, peer_addr: &[u8; 6]) -> Result<()> {
         sender::send_imu(&mut self.esp_now, timestamp_us, data, peer_addr).await
     }
 
     /// Send GPS data to a peer
-    #[allow(dead_code)]
     pub async fn send_gps(&mut self, timestamp_us: u64, data: &GpsData, peer_addr: &[u8; 6]) -> Result<()> {
         sender::send_gps(&mut self.esp_now, timestamp_us, data, peer_addr).await
     }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -8,7 +8,7 @@ use byteorder::{ByteOrder, LittleEndian};
 
 use super::message::*;
 use super::error::{AirCommError, Result};
-use crate::types::{GpsData, GpsTime};
+use crate::types::{GpsData, GpsTime, ImuData};
 
 /// Maximum payload size for ESP-NOW (250 bytes)
 pub const MAX_PAYLOAD_SIZE: usize = 250;
@@ -52,7 +52,7 @@ pub fn serialize_heartbeat(timestamp_us: u64, data: &HeartbeatData, buffer: &mut
 
 /// Serialize IMU data into a byte buffer
 ///
-/// Format: [MessageType:1][Timestamp:8][ImuData:TBD]
+/// Format: [MessageType:1][Timestamp:8][accel_x:4][accel_y:4][accel_z:4][gyro_x:4][gyro_y:4][gyro_z:4]
 ///
 /// # Arguments
 /// * `timestamp_us` - Sender's timestamp in microseconds
@@ -67,12 +67,37 @@ pub fn serialize_imu(timestamp_us: u64, data: &ImuData, buffer: &mut [u8]) -> Re
         return Err(AirCommError::BufferTooSmall);
     }
 
-    // TODO: Implement serialization
-    // - Write message type
-    // - Write timestamp
-    // - Write IMU data fields in little-endian format
+    let mut offset = 0;
     
-    todo!("Implement serialize_imu")
+    // Write message type
+    buffer[offset] = MessageType::Imu.to_u8();
+    offset += 1;
+    
+    // Write timestamp
+    LittleEndian::write_u64(&mut buffer[offset..], timestamp_us);
+    offset += 8;
+    
+    // Write accelerometer data
+    LittleEndian::write_f32(&mut buffer[offset..], data.accel_x);
+    offset += 4;
+    
+    LittleEndian::write_f32(&mut buffer[offset..], data.accel_y);
+    offset += 4;
+    
+    LittleEndian::write_f32(&mut buffer[offset..], data.accel_z);
+    offset += 4;
+    
+    // Write gyroscope data
+    LittleEndian::write_f32(&mut buffer[offset..], data.gyro_x);
+    offset += 4;
+    
+    LittleEndian::write_f32(&mut buffer[offset..], data.gyro_y);
+    offset += 4;
+    
+    LittleEndian::write_f32(&mut buffer[offset..], data.gyro_z);
+    offset += 4;
+    
+    Ok(offset)
 }
 
 /// Serialize GPS data into a byte buffer
@@ -179,9 +204,41 @@ pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
 }
 
 /// Deserialize IMU payload from buffer
-fn deserialize_imu(_data: &[u8], _payload_offset: usize) -> Result<SensorPayload> {
-    // TODO: Deserialize IMU data
-    todo!("Implement IMU deserialization")
+fn deserialize_imu(data: &[u8], payload_offset: usize) -> Result<SensorPayload> {
+    let required_size = HEADER_SIZE + IMU_SERIALIZED_SIZE;
+    if data.len() < required_size {
+        return Err(AirCommError::InvalidMessage);
+    }
+    
+    let mut offset = payload_offset;
+    
+    // Read accelerometer data
+    let accel_x = LittleEndian::read_f32(&data[offset..]);
+    offset += 4;
+    
+    let accel_y = LittleEndian::read_f32(&data[offset..]);
+    offset += 4;
+    
+    let accel_z = LittleEndian::read_f32(&data[offset..]);
+    offset += 4;
+    
+    // Read gyroscope data
+    let gyro_x = LittleEndian::read_f32(&data[offset..]);
+    offset += 4;
+    
+    let gyro_y = LittleEndian::read_f32(&data[offset..]);
+    offset += 4;
+    
+    let gyro_z = LittleEndian::read_f32(&data[offset..]);
+    
+    Ok(SensorPayload::Imu(ImuData {
+        accel_x,
+        accel_y,
+        accel_z,
+        gyro_x,
+        gyro_y,
+        gyro_z,
+    }))
 }
 
 /// Deserialize GPS payload from buffer
@@ -192,44 +249,44 @@ fn deserialize_gps(data: &[u8], payload_offset: usize) -> Result<SensorPayload> 
     }
     
     let mut offset = payload_offset;
-    
+
     // Read GPS fields
     let lat = LittleEndian::read_f64(&data[offset..]);
     offset += 8;
-    
+
     let lon = LittleEndian::read_f64(&data[offset..]);
     offset += 8;
-    
+
     let alt = LittleEndian::read_f32(&data[offset..]);
     offset += 4;
-    
+
     let speed_kts = LittleEndian::read_f32(&data[offset..]);
     offset += 4;
-    
+
     let heading = LittleEndian::read_u16(&data[offset..]);
     offset += 2;
-    
+
     // Read GpsTime fields
     let year = LittleEndian::read_u16(&data[offset..]);
     offset += 2;
-    
+
     let month = data[offset];
     offset += 1;
-    
+
     let day = data[offset];
     offset += 1;
-    
+
     let hours = data[offset];
     offset += 1;
-    
+
     let minutes = data[offset];
     offset += 1;
-    
+
     let seconds = data[offset];
     offset += 1;
-    
+
     let millis = LittleEndian::read_u16(&data[offset..]);
-    
+
     Ok(SensorPayload::Gps(GpsData {
         lat,
         lon,
@@ -254,7 +311,7 @@ fn deserialize_heartbeat(data: &[u8], payload_offset: usize) -> Result<SensorPay
     if data.len() < required_size {
         return Err(AirCommError::InvalidMessage);
     }
-    
+
     let magic = data[payload_offset];
     Ok(SensorPayload::Heartbeat(HeartbeatData { magic }))
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
@@ -27,7 +27,6 @@ pub(crate) async fn send_heartbeat(
 }
 
 /// Send IMU data asynchronously
-#[allow(dead_code)]
 pub(crate) async fn send_imu(
     esp_now: &mut EspNow<'_>,
     timestamp_us: u64,
@@ -43,7 +42,6 @@ pub(crate) async fn send_imu(
 }
 
 /// Send GPS data asynchronously
-#[allow(dead_code)]
 pub(crate) async fn send_gps(
     esp_now: &mut EspNow<'_>,
     timestamp_us: u64,

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -12,6 +12,11 @@ use esp_hal::gpio::Output;
 use log::{debug, error, info, trace, warn};
 
 #[cfg(feature = "wifi")]
+use embassy_sync::channel::Channel;
+#[cfg(feature = "wifi")]
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
+#[cfg(feature = "wifi")]
 use crate::aircomm::{AirCommTransceiver, HeartbeatData, SensorMessage, SensorPayload, BROADCAST};
 #[cfg(feature = "gps")]
 use crate::gps::{init_gps, start_gps};
@@ -20,8 +25,21 @@ use crate::hmi::{neopixel, start_hmi};
 #[cfg(feature = "imu")]
 use crate::imu::start_imu;
 use crate::BoardPeripherals;
+#[cfg(feature = "wifi")]
+use crate::EspNowMode;
 #[cfg(feature = "imu")]
 use crate::SharedSpiDevice;
+
+/// Capacity of the sensor data channel
+/// Allows buffering sensor samples while ESP-NOW sends
+#[cfg(feature = "wifi")]
+const SENSOR_CHANNEL_CAPACITY: usize = 8;
+
+/// Sensor data channel for inter-task communication
+/// Sensors push data here, ESP-NOW sender task consumes and transmits
+#[cfg(feature = "wifi")]
+static SENSOR_CHANNEL: Channel<CriticalSectionRawMutex, SensorPayload, SENSOR_CHANNEL_CAPACITY> =
+    Channel::new();
 
 pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mut board: B) {
     info!("app is starting execution now");
@@ -30,22 +48,22 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
     let user_led = board.take_user_led();
     #[cfg(feature = "hmi")]
     trace!("User Led initialized!");
-    
+
     #[cfg(feature = "hmi")]
     let neopixel = board.take_neopixel();
     #[cfg(feature = "hmi")]
     trace!("NeoPixel initialized!");
-    
+
     #[cfg(feature = "hmi")]
     let _disp_spi_device = board.take_disp_spi_device();
     #[cfg(feature = "hmi")]
     trace!("DISPLAY_SPI device taken");
-    
+
     #[cfg(feature = "imu")]
     let imu_spi_device = board.take_imu_spi_device();
     #[cfg(feature = "imu")]
     trace!("IMU_SPI device taken");
-    
+
     #[cfg(feature = "gps")]
     let gps2_uart = board.take_gps2_uart();
     #[cfg(feature = "gps")]
@@ -58,32 +76,48 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
         .spawn(start_hmi_task(user_led, neopixel))
         .expect("HMI task did not spawn");
 
+    // Sensor tasks with callbacks for data
     #[cfg(feature = "imu")]
     spawner
         .spawn(start_imu_task(imu_spi_device))
         .expect("imu task did not spawn");
-    
+
     #[cfg(feature = "gps")]
     spawner
         .spawn(start_gps_task(gps2_uart))
         .expect("GPS task did not spawn");
 
-    // ESP-NOW / AirComm task
+    // WiFi/ESP-NOW tasks - spawn based on board's configured mode
     #[cfg(feature = "wifi")]
-    if let Some(wifi) = board.take_wifi() {
-        match AirCommTransceiver::new(wifi.esp_now) {
-            Ok(transceiver) => {
-                info!("AirComm transceiver initialized");
-                spawner
-                    .spawn(espnow_task(transceiver, wifi.controller))
-                    .expect("ESP-NOW task did not spawn");
+    {
+        let mode = board.espnow_mode();
+        if let Some(wifi) = board.take_wifi() {
+            match AirCommTransceiver::new(wifi.esp_now) {
+                Ok(transceiver) => {
+                    info!("AirComm transceiver initialized");
+
+                    match mode {
+                        EspNowMode::Sender => {
+                            info!("ESP-NOW mode: Sender (transmit sensor data)");
+                            spawner
+                                .spawn(espnow_sender_task(transceiver, wifi.controller))
+                                .expect("ESP-NOW sender task did not spawn");
+                        }
+                        EspNowMode::Transceiver => {
+                            info!("ESP-NOW mode: Transceiver (receive + heartbeat)");
+                            spawner
+                                .spawn(espnow_transceiver_task(transceiver, wifi.controller))
+                                .expect("ESP-NOW transceiver task did not spawn");
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to create AirComm transceiver: {:?}", e);
+                }
             }
-            Err(e) => {
-                warn!("Failed to create AirComm transceiver: {:?}", e);
-            }
+        } else {
+            warn!("WiFi not available - skipping wireless communication");
         }
-    } else {
-        warn!("WiFi not available - skipping wireless communication");
     }
 
     loop {
@@ -105,29 +139,73 @@ async fn start_hmi_task(user_led: Output<'static>, neopixel: neopixel::NeoPixel<
 #[embassy_executor::task]
 async fn start_imu_task(imu_spi_device: SharedSpiDevice) {
     info!("IMU TASK BEING SPAWNED");
-    start_imu(imu_spi_device).await;
+
+    // Callback: send IMU data to channel for transmission
+    #[cfg(feature = "wifi")]
+    let on_imu_data = |data: crate::types::ImuData| {
+        if SENSOR_CHANNEL
+            .try_send(SensorPayload::Imu(data))
+            .is_err()
+        {
+            warn!("[IMU] Channel full, dropping sample");
+        } else {
+            trace!("[IMU] Sent data to channel");
+        }
+    };
+
+    // No-op callback when wifi is disabled
+    #[cfg(not(feature = "wifi"))]
+    let on_imu_data = |_data: crate::types::ImuData| {
+        // Data is logged in start_imu, nothing else to do
+    };
+
+    start_imu(imu_spi_device, on_imu_data).await;
 }
 
 #[cfg(feature = "gps")]
 #[embassy_executor::task]
 async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Async>) {
     gps2_uart = init_gps(gps2_uart).await;
-    start_gps(gps2_uart).await;
+
+    // Callback: send GPS data to channel for transmission
+    #[cfg(feature = "wifi")]
+    let on_gps_data = |data: crate::types::GpsData| {
+        if SENSOR_CHANNEL
+            .try_send(SensorPayload::Gps(data))
+            .is_err()
+        {
+            warn!("[GPS] Channel full, dropping sample");
+        } else {
+            trace!("[GPS] Sent data to channel");
+        }
+    };
+
+    // No-op callback when wifi is disabled
+    #[cfg(not(feature = "wifi"))]
+    let on_gps_data = |_data: crate::types::GpsData| {
+        // Data is logged in start_gps, nothing else to do
+    };
+
+    start_gps(gps2_uart, on_gps_data).await;
 }
+
+// =============================================================================
+// ESP-NOW Tasks
+// =============================================================================
 
 /// ESP-NOW transceiver task
 ///
-/// Handles both sending heartbeats at regular intervals and receiving messages.
-/// Uses timeout-based receive to avoid blocking heartbeat transmission.
+/// Handles both receiving ESP-NOW messages and sending periodic heartbeats.
+/// Used by bridge/receiver nodes (e.g., DevKit-C) for testing or forwarding data.
 ///
 /// Note: `_wifi_controller` must be kept alive for ESP-NOW to function properly.
 #[cfg(feature = "wifi")]
 #[embassy_executor::task]
-async fn espnow_task(
+async fn espnow_transceiver_task(
     mut transceiver: AirCommTransceiver<'static>,
     _wifi_controller: esp_radio::wifi::WifiController<'static>,
 ) {
-    info!("[ESP-NOW] Task started");
+    info!("[ESP-NOW] Transceiver task started (RX + TX heartbeats)");
 
     const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -144,7 +222,7 @@ async fn espnow_task(
             HEARTBEAT_INTERVAL - elapsed
         };
 
-        // Try to receive with timeout (doesn't cancel the receive, just times out)
+        // Try to receive with timeout
         match embassy_time::with_timeout(timeout, transceiver.receive()).await {
             Ok(Ok(msg)) => {
                 // Successfully received a message
@@ -167,12 +245,93 @@ async fn espnow_task(
     }
 }
 
+/// ESP-NOW sender task (default)
+///
+/// Receives sensor data from the channel and transmits via ESP-NOW.
+/// Also sends periodic heartbeats to indicate the node is alive.
+///
+/// Note: `_wifi_controller` must be kept alive for ESP-NOW to function properly.
+#[cfg(feature = "wifi")]
+#[embassy_executor::task]
+async fn espnow_sender_task(
+    mut transceiver: AirCommTransceiver<'static>,
+    _wifi_controller: esp_radio::wifi::WifiController<'static>,
+) {
+    info!("[ESP-NOW] Sender task started");
+
+    const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+
+    // Send first heartbeat immediately
+    send_heartbeat(&mut transceiver).await;
+    let mut last_heartbeat = Instant::now();
+
+    loop {
+        // Calculate how long until next heartbeat is due
+        let elapsed = last_heartbeat.elapsed();
+        let timeout = if elapsed >= HEARTBEAT_INTERVAL {
+            Duration::from_millis(0)
+        } else {
+            HEARTBEAT_INTERVAL - elapsed
+        };
+
+        // Try to receive sensor data from channel with timeout
+        match embassy_time::with_timeout(timeout, SENSOR_CHANNEL.receive()).await {
+            Ok(payload) => {
+                // Got sensor data, transmit it
+                let timestamp_us = Instant::now().as_micros();
+
+                let result = match &payload {
+                    SensorPayload::Imu(data) => {
+                        debug!("[ESP-NOW TX] Sending IMU data");
+                        transceiver.send_imu(timestamp_us, data, &BROADCAST).await
+                    }
+                    SensorPayload::Gps(data) => {
+                        debug!("[ESP-NOW TX] Sending GPS data");
+                        transceiver.send_gps(timestamp_us, data, &BROADCAST).await
+                    }
+                    SensorPayload::Heartbeat(data) => {
+                        debug!("[ESP-NOW TX] Sending Heartbeat");
+                        transceiver
+                            .send_heartbeat(timestamp_us, data, &BROADCAST)
+                            .await
+                    }
+                };
+
+                match result {
+                    Ok(()) => {
+                        trace!("[ESP-NOW TX] Sent {:?}", payload.message_type());
+                    }
+                    Err(e) => {
+                        warn!("[ESP-NOW TX] Send failed: {:?}", e);
+                    }
+                }
+            }
+            Err(_) => {
+                // Timeout - no sensor data, that's fine
+            }
+        }
+
+        // Check if it's time to send heartbeat
+        if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
+            send_heartbeat(&mut transceiver).await;
+            last_heartbeat = Instant::now();
+        }
+    }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
 #[cfg(feature = "wifi")]
 async fn send_heartbeat(transceiver: &mut AirCommTransceiver<'static>) {
     let timestamp_us = Instant::now().as_micros();
     let heartbeat = HeartbeatData::default();
 
-    match transceiver.send_heartbeat(timestamp_us, &heartbeat, &BROADCAST).await {
+    match transceiver
+        .send_heartbeat(timestamp_us, &heartbeat, &BROADCAST)
+        .await
+    {
         Ok(()) => {
             info!("[ESP-NOW TX] Heartbeat sent (time={}us)", timestamp_us);
         }
@@ -186,7 +345,7 @@ async fn send_heartbeat(transceiver: &mut AirCommTransceiver<'static>) {
 fn handle_received_message(msg: &SensorMessage) {
     let src = msg.src_address;
     let timestamp = msg.timestamp_us;
-    
+
     match &msg.payload {
         SensorPayload::Heartbeat(data) => {
             info!(
@@ -195,11 +354,11 @@ fn handle_received_message(msg: &SensorMessage) {
                 data.magic, timestamp
             );
         }
-        SensorPayload::Imu(_data) => {
+        SensorPayload::Imu(data) => {
             info!(
-                "[ESP-NOW RX] IMU from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | time={}us, TODO: IMU fields",
+                "[ESP-NOW RX] IMU from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | time={}us, accel=[{:.3}, {:.3}, {:.3}]",
                 src[0], src[1], src[2], src[3], src[4], src[5],
-                timestamp
+                timestamp, data.accel_x, data.accel_y, data.accel_z
             );
         }
         SensorPayload::Gps(data) => {

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -22,7 +22,7 @@ use sensor_board_rev1_test::hmi::neopixel;
 #[cfg(any(feature = "hmi", feature = "imu"))]
 use sensor_board_rev1_test::{SharedSpiBus, SharedSpiDevice};
 #[cfg(feature = "wifi")]
-use sensor_board_rev1_test::WifiResources;
+use sensor_board_rev1_test::{EspNowMode, WifiResources};
 use sensor_board_rev1_test::{BoardPeripherals, app::app_run};
 
 #[cfg(any(feature = "hmi", feature = "imu"))]
@@ -214,6 +214,12 @@ impl BoardPeripherals for DevkitC {
     fn take_wifi(&mut self) -> Option<WifiResources> {
         trace!("wifi take called");
         self.wifi.take()
+    }
+
+    #[cfg(feature = "wifi")]
+    fn espnow_mode(&self) -> EspNowMode {
+        // DevKit-C acts as a generic receiver for now
+        EspNowMode::Transceiver
     }
 }
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_rev1.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_rev1.rs
@@ -6,18 +6,26 @@
     holding buffers for the duration of a data transfer."
 )]
 
+#[cfg(any(feature = "hmi", feature = "imu"))]
 use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
+#[cfg(any(feature = "hmi", feature = "imu"))]
 use embassy_sync::mutex::Mutex;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
+#[cfg(any(feature = "hmi", feature = "imu"))]
 use static_cell::StaticCell;
 
 use esp_alloc as _;
 
-use sensor_board_rev1_test::{
-    BoardPeripherals, SharedSpiBus, SharedSpiDevice, app::app_run, hmi::neopixel,
-};
+#[cfg(feature = "hmi")]
+use sensor_board_rev1_test::hmi::neopixel;
+#[cfg(any(feature = "hmi", feature = "imu"))]
+use sensor_board_rev1_test::{SharedSpiBus, SharedSpiDevice};
+#[cfg(feature = "wifi")]
+use sensor_board_rev1_test::{EspNowMode, WifiResources};
+use sensor_board_rev1_test::{BoardPeripherals, app::app_run};
 
+#[cfg(any(feature = "hmi", feature = "imu"))]
 static SPI_BUS: StaticCell<SharedSpiBus> = StaticCell::new();
 
 #[panic_handler]
@@ -44,14 +52,18 @@ fn init_heap() {
 }
 
 pub struct SensorBoardRev1 {
-    // HMI
+    #[cfg(feature = "hmi")]
     pub user_led: Option<esp_hal::gpio::Output<'static>>,
+    #[cfg(feature = "hmi")]
     pub neopixel: Option<neopixel::NeoPixel<'static>>,
+    #[cfg(feature = "hmi")]
     pub disp_spi: Option<SharedSpiDevice>,
-
-    // SENSORS
+    #[cfg(feature = "imu")]
     pub imu_spi: Option<SharedSpiDevice>,
+    #[cfg(feature = "gps")]
     pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Async>>,
+    #[cfg(feature = "wifi")]
+    pub wifi: Option<WifiResources>,
 }
 
 impl SensorBoardRev1 {
@@ -64,6 +76,8 @@ impl SensorBoardRev1 {
         esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
         debug!(">>> building SensorBoardRev1");
 
+        // HMI peripherals
+        #[cfg(feature = "hmi")]
         let user_led = esp_hal::gpio::Output::new(
             peripherals.GPIO19,
             esp_hal::gpio::Level::High,
@@ -71,7 +85,9 @@ impl SensorBoardRev1 {
         );
 
         let rmt =
-            esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80)).unwrap();
+            esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80))
+                .unwrap()
+                .into_async();
         let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO18);
 
         let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(9600);
@@ -105,28 +121,63 @@ impl SensorBoardRev1 {
         let imu_spi_device = SpiDevice::new(spi_bus, imu_spi2_cs);
         let disp_spi_device = SpiDevice::new(spi_bus, disp_spi2_cs);
 
+        // WiFi initialization
+        #[cfg(feature = "wifi")]
+        let wifi = match esp_radio::wifi::new(peripherals.WIFI, esp_radio::wifi::Config::default())
+        {
+            Ok((mut wifi_controller, interfaces)) => {
+                info!("WiFi initialized successfully");
+                if let Err(e) = wifi_controller.set_mode(esp_radio::wifi::WifiMode::Station) {
+                    warn!("Failed to set WiFi mode: {:?}", e);
+                    None
+                } else if let Err(e) = wifi_controller.start() {
+                    warn!("Failed to start WiFi controller: {:?}", e);
+                    None
+                } else {
+                    Some(WifiResources {
+                        controller: wifi_controller,
+                        esp_now: interfaces.esp_now,
+                    })
+                }
+            }
+            Err(e) => {
+                warn!("WiFi initialization failed: {:?}", e);
+                None
+            }
+        };
+
         debug!(">>> SensorBoardRev1 returned things correctly");
         Self {
+            #[cfg(feature = "hmi")]
             user_led: Some(user_led),
+            #[cfg(feature = "hmi")]
             neopixel: Some(neopixel),
+            #[cfg(feature = "hmi")]
             disp_spi: Some(disp_spi_device),
+            #[cfg(feature = "imu")]
             imu_spi: Some(imu_spi_device),
+            #[cfg(feature = "gps")]
             gps2_uart: Some(gps2_uart),
+            #[cfg(feature = "wifi")]
+            wifi,
         }
     }
 }
 
 impl BoardPeripherals for SensorBoardRev1 {
+    #[cfg(feature = "hmi")]
     fn take_user_led(&mut self) -> esp_hal::gpio::Output<'static> {
         trace!("user led take called");
         self.user_led.take().expect("user LED already taken")
     }
 
+    #[cfg(feature = "hmi")]
     fn take_neopixel(&mut self) -> neopixel::NeoPixel<'static> {
         trace!("neopixel take called");
         self.neopixel.take().expect("NeoPixel already taken")
     }
 
+    #[cfg(feature = "hmi")]
     fn take_disp_spi_device(&mut self) -> SharedSpiDevice {
         trace!("disp_spi_device take called");
         self.disp_spi
@@ -134,14 +185,28 @@ impl BoardPeripherals for SensorBoardRev1 {
             .expect("DisplaySPI device already taken")
     }
 
+    #[cfg(feature = "imu")]
     fn take_imu_spi_device(&mut self) -> SharedSpiDevice {
         trace!("imu_spi_device take called");
         self.imu_spi.take().expect("ImuSPI device already taken")
     }
 
+    #[cfg(feature = "gps")]
     fn take_gps2_uart(&mut self) -> esp_hal::uart::Uart<'static, esp_hal::Async> {
         trace!("gps2_uart take called");
         self.gps2_uart.take().expect("gps2_uart already taken")
+    }
+
+    #[cfg(feature = "wifi")]
+    fn take_wifi(&mut self) -> Option<WifiResources> {
+        trace!("wifi take called");
+        self.wifi.take()
+    }
+
+    #[cfg(feature = "wifi")]
+    fn espnow_mode(&self) -> EspNowMode {
+        // Sensor board sends data to bridge
+        EspNowMode::Sender
     }
 }
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -5,6 +5,8 @@ use heapless::String;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
+use crate::types::{GpsData, GpsTime};
+
 const NMEA_0183_MAX_LENGTH: usize = 83;
 const MAX_SENTENCE_LENGTH: usize = NMEA_0183_MAX_LENGTH + 2; // give ourselves buffer for newlines
 const NUM_NMEA_SENTENCES: usize = 3; // RMC, VTG, GGA
@@ -64,12 +66,34 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
     gps2_uart
 }
 
-pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
+/// Start GPS task with a callback for each data sample
+///
+/// The callback `on_data` is invoked whenever a valid GPS fix is available.
+/// This allows the caller to decide what to do with the data (log, send, etc.)
+/// without the driver needing to know about channels or networking.
+///
+/// # Arguments
+/// * `gps2_uart` - The UART peripheral for GPS communication
+/// * `on_data` - Callback invoked with each GPS fix
+pub async fn start_gps<F>(mut gps2_uart: Uart<'static, Async>, on_data: F)
+where
+    F: Fn(GpsData),
+{
+    use nmea_parser::chrono::{Datelike, Timelike};
+
     let mut parser = nmea_parser::NmeaParser::new();
 
     // Use a String to buffer incomplete lines across loop iterations
     let mut incomplete_line_buffer: heapless::String<UNPROCESSED_BUFF_SIZE> =
         heapless::String::new();
+
+    // Track latest values from different NMEA sentences
+    let mut last_lat: Option<f64> = None;
+    let mut last_lon: Option<f64> = None;
+    let mut last_alt: Option<f32> = None;
+    let mut last_speed_kts: Option<f32> = None;
+    let mut last_heading: Option<u16> = None;
+    let mut last_time: Option<GpsTime> = None;
 
     loop {
         let mut buf = [0u8; CHUNK_BUFF_SIZE];
@@ -111,10 +135,57 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
                                 gga.hdop.unwrap_or(0.0),
                                 gga.satellite_count.unwrap_or(0),
                             );
+
+                            // Update cached values from GGA
+                            if let Some(lat) = gga.latitude {
+                                last_lat = Some(lat);
+                            }
+                            if let Some(lon) = gga.longitude {
+                                last_lon = Some(lon);
+                            }
+                            if let Some(alt) = gga.altitude {
+                                last_alt = Some(alt as f32);
+                            }
+
+                            // Try to construct and send GPS data if we have position
+                            try_send_gps_data(
+                                &on_data,
+                                last_lat,
+                                last_lon,
+                                last_alt,
+                                last_speed_kts,
+                                last_heading,
+                                last_time,
+                            );
                         }
                         nmea_parser::ParsedMessage::Rmc(rmc) => {
                             if let Some(time) = rmc.timestamp {
                                 info!("GPS rmc time is: {}", time);
+
+                                // Update cached time from RMC
+                                last_time = Some(GpsTime {
+                                    year: time.year() as u16,
+                                    month: time.month() as u8,
+                                    day: time.day() as u8,
+                                    hours: time.hour() as u8,
+                                    minutes: time.minute() as u8,
+                                    seconds: time.second() as u8,
+                                    millis: (time.nanosecond() / 1_000_000) as u16,
+                                });
+                            }
+
+                            // RMC also contains position data
+                            if let Some(lat) = rmc.latitude {
+                                last_lat = Some(lat);
+                            }
+                            if let Some(lon) = rmc.longitude {
+                                last_lon = Some(lon);
+                            }
+                            if let Some(sog) = rmc.sog_knots {
+                                last_speed_kts = Some(sog as f32);
+                            }
+                            if let Some(bearing) = rmc.bearing {
+                                last_heading = Some(bearing as u16);
                             }
                         }
                         nmea_parser::ParsedMessage::Vtg(vtg) => {
@@ -124,6 +195,25 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
                             info!(
                                 "GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
                                 speed_knots, speed_kph, course
+                            );
+
+                            // Update cached values from VTG
+                            if vtg.sog_knots.is_some() {
+                                last_speed_kts = Some(speed_knots as f32);
+                            }
+                            if vtg.cog_true.is_some() {
+                                last_heading = Some(course as u16);
+                            }
+
+                            // Try to construct and send GPS data after VTG
+                            try_send_gps_data(
+                                &on_data,
+                                last_lat,
+                                last_lon,
+                                last_alt,
+                                last_speed_kts,
+                                last_heading,
+                                last_time,
                             );
                         }
                         other_message => {
@@ -153,5 +243,40 @@ pub async fn start_gps(mut gps2_uart: Uart<'static, Async>) {
         } else {
             incomplete_line_buffer.clear(); // everything processed
         }
+    }
+}
+
+/// Helper to construct and send GPS data if we have at least position
+fn try_send_gps_data<F>(
+    on_data: &F,
+    lat: Option<f64>,
+    lon: Option<f64>,
+    alt: Option<f32>,
+    speed_kts: Option<f32>,
+    heading: Option<u16>,
+    time: Option<GpsTime>,
+)
+where
+    F: Fn(GpsData),
+{
+    // Only send if we have at least lat/lon
+    if let (Some(lat), Some(lon)) = (lat, lon) {
+        let gps_data = GpsData {
+            lat,
+            lon,
+            alt: alt.unwrap_or(0.0),
+            speed_kts: speed_kts.unwrap_or(0.0),
+            heading: heading.unwrap_or(0),
+            utc_time: time.unwrap_or(GpsTime {
+                year: 0,
+                month: 0,
+                day: 0,
+                hours: 0,
+                minutes: 0,
+                seconds: 0,
+                millis: 0,
+            }),
+        };
+        on_data(gps_data);
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
@@ -3,10 +3,23 @@ use log::{debug, error, info, trace, warn};
 
 use embassy_time::{Duration, Timer};
 
-use crate::old_asm330::{AccelFs, GyroFs, Odr};
+use crate::old_asm330::{AccelFs, Odr};
+use crate::types::ImuData;
 use crate::{SharedSpiDevice, old_asm330};
 
-pub async fn start_imu(mut spi: SharedSpiDevice) {
+/// Start IMU task with a callback for each data sample
+///
+/// The callback `on_data` is invoked whenever new IMU data is available.
+/// This allows the caller to decide what to do with the data (log, send, etc.)
+/// without the driver needing to know about channels or networking.
+///
+/// # Arguments
+/// * `spi` - The shared SPI device for IMU communication
+/// * `on_data` - Callback invoked with each IMU sample
+pub async fn start_imu<F>(mut spi: SharedSpiDevice, on_data: F)
+where
+    F: Fn(ImuData),
+{
     info!("In imu task!");
     match old_asm330::check_who_am_i(&mut spi).await {
         Ok(val) => {
@@ -18,10 +31,10 @@ pub async fn start_imu(mut spi: SharedSpiDevice) {
     }
     let fsr_a = AccelFs::G2;
     let odr_a = Odr::Hz104;
-    let _ = old_asm330::set_xl_fsr(&mut spi, &fsr_a);
-    let _ = old_asm330::set_xl_odr(&mut spi, odr_a);
+    let _ = old_asm330::set_xl_fsr(&mut spi, &fsr_a).await;
+    let _ = old_asm330::set_xl_odr(&mut spi, odr_a).await;
 
-    let period = Duration::from_hz(1);
+    let period = Duration::from_hz(2);
     loop {
         match old_asm330::read_xl_xyz(&mut spi).await {
             Ok(xl_raw_data) => {
@@ -37,6 +50,18 @@ pub async fn start_imu(mut spi: SharedSpiDevice) {
                     "Accel: X={:.3}g Y={:.3}g Z={:.3}g",
                     accel_x_g, accel_y_g, accel_z_g
                 );
+
+                // Invoke callback with IMU data
+                // Note: Gyro data is zeroed until driver supports gyroscope
+                let imu_data = ImuData {
+                    accel_x: accel_x_g,
+                    accel_y: accel_y_g,
+                    accel_z: accel_z_g,
+                    gyro_x: 0.0,
+                    gyro_y: 0.0,
+                    gyro_z: 0.0,
+                };
+                on_data(imu_data);
             }
             Err(e) => {
                 warn!("Failed to read XL XYZ: {:?}", e);

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -28,6 +28,18 @@ pub type SharedSpiBus = Mutex<NoopRawMutex, Spi<'static, Async>>;
 
 pub type SharedSpiDevice = SpiDevice<'static, NoopRawMutex, Spi<'static, Async>, Output<'static>>;
 
+/// ESP-NOW operating mode for the board
+#[cfg(feature = "wifi")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EspNowMode {
+    /// Sender mode: transmits sensor data from channel + heartbeats
+    /// Used by sensor nodes that collect and send data
+    Sender,
+    /// Transceiver mode: receives ESP-NOW messages + sends heartbeats
+    /// Used for testing purposes, receives data from other nodes
+    Transceiver,
+}
+
 /// WiFi resources bundle containing the controller and available interfaces
 #[cfg(feature = "wifi")]
 pub struct WifiResources {
@@ -55,4 +67,8 @@ pub trait BoardPeripherals {
     // WIRELESS
     #[cfg(feature = "wifi")]
     fn take_wifi(&mut self) -> Option<WifiResources>;
+
+    /// Returns the ESP-NOW operating mode for this board
+    #[cfg(feature = "wifi")]
+    fn espnow_mode(&self) -> EspNowMode;
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/old_asm330.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/old_asm330.rs
@@ -383,16 +383,18 @@ where
     S::Error: core::fmt::Debug,
 {
     debug!("Attempting to read raw XL XYZ registers");
-    const READ_CMD: u8 = 0x80 | REG_OUTX_L_A; // in place read all 6 bytes
-    let mut buf: [u8; 6] = [READ_CMD, 0, 0, 0, 0, 0];
+    const READ_CMD: u8 = 0x80 | REG_OUTX_L_A;
+    // Need 7 bytes: 1 command + 6 data bytes (X_L, X_H, Y_L, Y_H, Z_L, Z_H)
+    let mut buf: [u8; 7] = [READ_CMD, 0, 0, 0, 0, 0, 0];
     spi.transfer_in_place(&mut buf).await?;
-    let x = i16::from_le_bytes([buf[0], buf[1]]);
-    let y = i16::from_le_bytes([buf[2], buf[3]]);
-    let z = i16::from_le_bytes([buf[4], buf[5]]);
+    // After transfer: buf[0] = garbage, buf[1..7] = data
+    let x = i16::from_le_bytes([buf[1], buf[2]]);
+    let y = i16::from_le_bytes([buf[3], buf[4]]);
+    let z = i16::from_le_bytes([buf[5], buf[6]]);
 
     debug!("Got X, Y, Z raw as {} {} {}", x, y, z);
 
-    Ok(XlRawData { x: x, y: y, z: z })
+    Ok(XlRawData { x, y, z })
 }
 
 pub async fn read_xl_x<S>(spi: &mut S) -> Result<i16, S::Error>

--- a/sw/sensor_board/sensor_board_rev1_test/src/types.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/types.rs
@@ -4,7 +4,18 @@
 /// IMU sensor data structure
 #[derive(Debug, Clone, Copy)]
 pub struct ImuData {
-    // TODO: IMU data fields
+    /// Accelerometer X-axis in g
+    pub accel_x: f32,
+    /// Accelerometer Y-axis in g
+    pub accel_y: f32,
+    /// Accelerometer Z-axis in g
+    pub accel_z: f32,
+    /// Gyroscope X-axis in degrees/second
+    pub gyro_x: f32,
+    /// Gyroscope Y-axis in degrees/second
+    pub gyro_y: f32,
+    /// Gyroscope Z-axis in degrees/second
+    pub gyro_z: f32,
 }
 
 /// GPS timestamp


### PR DESCRIPTION
# feat: Add sensor data flow via ESP-NOW with board-specific modes
This PR implements the dataflow pipeline from sensor board rev1, allowing it to act as data acquisition machine for IMU and GPS data.

# Changes
- Added callback pattern for drivers. `start_imu` and `start_gps` now accept a callback function parameter that is triggered automatically when a piece of data is successfully retrieved. This allows the network layer to transmit the espnow message once there is a callback event. 
- Channel based communication. Using `embassy_sync::Channel` for buffering the sensor data between driver tasks and the espnow sender task
- Added a board-based espnow mode. This is an enum that is matched with the board and defines the type of espnow task.

# Testing
- Tested with one rev1 board flashed with rev1_board firmware. It acts as the data acquisition machine that keeps sending out data (IMU only for now).
- Another board flashed with devkit_c firmware. It acts as a simple data receiver. It prints whatever it receives.
- The screenshot below is what we can see from the board with devkit_c firmware.
<img width="779" height="516" alt="image" src="https://github.com/user-attachments/assets/9d81095c-479d-4dd0-aaa5-a1064f49a429" />

- IMU running at 2 Hz, placed at a not decent table.
- The board collects the imu but since it is receiver, it doesn't send it, that is why it is complaining a bit about data overflowing.
- One day, when the dev is mostly done. We will keep remove these basic printouts, otherwise the printout at 100Hz IMU will be insane.