### PR TITLE
F10 GPS Hi_Rate

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_rev1.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_rev1.rs
@@ -89,7 +89,7 @@ impl SensorBoardRev1 {
             .into_async();
         let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO18);
 
-        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(9600);
+        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(38400);
         info!("baudrate for gps2_uart_set");
         let gps2_uart = esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
             .unwrap()

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_rev1.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_rev1.rs
@@ -89,7 +89,7 @@ impl SensorBoardRev1 {
             .into_async();
         let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO18);
 
-        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(38400);
+        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(460800);
         info!("baudrate for gps2_uart_set");
         let gps2_uart = esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
             .unwrap()

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -1,7 +1,7 @@
 use core::fmt::Write;
 use esp_hal::Async;
 use esp_hal::uart::Uart;
-use heapless::String;
+use heapless::{String, Vec};
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
@@ -46,6 +46,50 @@ async fn send_nmea_command(uart: &mut Uart<'static, Async>, payload: &str, name:
     }
 }
 
+async fn send_ubx_packet(
+    uart: &mut Uart<'static, Async>,
+    class: u8,
+    id: u8,
+    payload: &[u8],
+    name: &str,
+) {
+    let len = payload.len() as u16;
+    let len_bytes = len.to_le_bytes(); // UBX is Little Endian
+
+    // 1. Build the part of the packet used for checksum calculation
+    // Checksum is calculated over: Class, ID, Length, and Payload
+    let mut checksum_data = Vec::<u8, 128>::new(); // Use a fixed-capacity stack vector
+    checksum_data.push(class).ok();
+    checksum_data.push(id).ok();
+    checksum_data.extend_from_slice(&len_bytes).ok();
+    checksum_data.extend_from_slice(payload).ok();
+
+    // 2. Calculate Fletcher-8 Checksum
+    let mut ck_a: u8 = 0;
+    let mut ck_b: u8 = 0;
+    for &byte in checksum_data.iter() {
+        ck_a = ck_a.wrapping_add(byte);
+        ck_b = ck_b.wrapping_add(ck_a);
+    }
+
+    // 3. Assemble the full frame
+    // [Sync1, Sync2, ChecksumData..., CK_A, CK_B]
+    let mut full_packet = Vec::<u8, 134>::new();
+    full_packet.push(0xB5).ok(); // Sync 1
+    full_packet.push(0x62).ok(); // Sync 2
+    full_packet.extend_from_slice(&checksum_data).ok();
+    full_packet.push(ck_a).ok();
+    full_packet.push(ck_b).ok();
+
+    info!("Sending UBX {} command...", name);
+
+    // 4. Send over UART
+    match uart.write_async(&full_packet).await {
+        Ok(_) => info!("UBX {} sent.", name),
+        Err(e) => error!("Failed to send UBX {}: {:?}", name, e),
+    }
+}
+
 pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uart<'static, Async> {
     info!("Starting GPS configuration using $PUBX,40 commands...");
 
@@ -75,13 +119,20 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
         0x06, 0x8A, // Class: CFG, ID: VALSET
         0x09, 0x00, // Length: 9 bytes
         0x00, // Version 0
-        0x01, // Layers (1 = RAM only, use 0x07 for RAM+Flash+BBR)
+        0x07, // Layers (1 = RAM only, use 0x07 for RAM+Flash+BBR)
         0x00, 0x00, // Reserved
         0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS (0x30210001) - Little Endian
         0x64, // 0x64 == 100 ms
         0x60, 0x34, // Checksum A/B
     ];
-    // send_ubx_packet(&mut gps2_uart, &UBX_CFG_VALSET_25HZ, "CFG-RATE-MEAS 25Hz").await;
+    send_ubx_packet(
+        &mut gps2_uart,
+        0x06, // class: CFG
+        0x8A, // id: valset
+        &UBX_CFG_VALSET_10HZ,
+        "CFG-RATE-MEAS 10Hz", // update this if 25
+    )
+    .await;
 
     gps2_uart
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -49,10 +49,6 @@ async fn send_nmea_command(uart: &mut Uart<'static, Async>, payload: &str, name:
 pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uart<'static, Async> {
     info!("Starting GPS configuration using $PUBX,40 commands...");
 
-    // TODO: Configure GPS for 10hz updates & 115200 baud
-    // ONLY DO THIS WHEN THE NEW GPS COMES IN, since we will have to set baud rate at configuration
-    // time, meaning we must set the baud for all the gps's, then change the code, then use the GPS
-
     // The payloads (excluding the leading '$' and trailing '*cs')
     const GSA_PAYLOAD: &str = "PUBX,40,GSA,0,0,0,0,0,0";
     const GSV_PAYLOAD: &str = "PUBX,40,GSV,0,0,0,0,0,0";
@@ -62,6 +58,30 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
     send_nmea_command(&mut gps2_uart, GSA_PAYLOAD, "GSA").await;
     send_nmea_command(&mut gps2_uart, GSV_PAYLOAD, "GSV").await;
     send_nmea_command(&mut gps2_uart, GLL_PAYLOAD, "GLL").await;
+
+    // TODO: Configure GPS for 10hz updates & 115200 baud
+    // ONLY DO THIS WHEN THE NEW GPS COMES IN, since we will have to set baud rate at configuration
+    // time, meaning we must set the baud for all the gps's, then change the code, then use the GPS
+
+    // This sets baud to 460800
+    // default for M8 is 9600, default for F10 is 38400. Reset to default, set high baud, then set
+    // high baud. Theoretically we can reconfigure the uart on the fly by dropping and re-creating
+    // but that seems really difficult and I don't want to do that
+    // send_nmea_command(&mut gps2_uart, "PUBX,41,1,3,3,460800,0", "SET BAUD 460800").await;
+
+    // This *should* set 10hz updates but I need to implement send_ubx_packet
+    const UBX_CFG_VALSET_10HZ: [u8; 17] = [
+        0xB5, 0x62, // Sync
+        0x06, 0x8A, // Class: CFG, ID: VALSET
+        0x09, 0x00, // Length: 9 bytes
+        0x00, // Version 0
+        0x01, // Layers (1 = RAM only, use 0x07 for RAM+Flash+BBR)
+        0x00, 0x00, // Reserved
+        0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS (0x30210001) - Little Endian
+        0x64, // 0x64 == 100 ms
+        0x60, 0x34, // Checksum A/B
+    ];
+    // send_ubx_packet(&mut gps2_uart, &UBX_CFG_VALSET_25HZ, "CFG-RATE-MEAS 25Hz").await;
 
     gps2_uart
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -54,6 +54,7 @@ async fn send_ubx_packet(
     name: &str,
 ) {
     let len = payload.len() as u16;
+    info!("payload len for msg UBX rate resolved to {}", len);
     let len_bytes = len.to_le_bytes(); // UBX is Little Endian
 
     // 1. Build the part of the packet used for checksum calculation
@@ -114,25 +115,23 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
     // send_nmea_command(&mut gps2_uart, "PUBX,41,1,3,3,460800,0", "SET BAUD 460800").await;
 
     // This *should* set 10hz updates but I need to implement send_ubx_packet
-    const UBX_CFG_VALSET_10HZ: [u8; 17] = [
-        0xB5, 0x62, // Sync
-        0x06, 0x8A, // Class: CFG, ID: VALSET
-        0x09, 0x00, // Length: 9 bytes
+    // Correct 10-byte payload for VALSET
+    const UBX_CFG_VALSET_10HZ_PAYLOAD: [u8; 10] = [
         0x00, // Version 0
-        0x07, // Layers (1 = RAM only, use 0x07 for RAM+Flash+BBR)
+        0x07, // Layer: 7 = RAM + Flash + BBR (Persistent)
         0x00, 0x00, // Reserved
-        0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS (0x30210001) - Little Endian
-        0x64, // 0x64 == 100 ms
-        0x60, 0x34, // Checksum A/B
+        0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS
+        0x64, 0x00, // Value: 100ms (Little Endian U2)
     ];
-    send_ubx_packet(
-        &mut gps2_uart,
-        0x06, // class: CFG
-        0x8A, // id: valset
-        &UBX_CFG_VALSET_10HZ,
-        "CFG-RATE-MEAS 10Hz", // update this if 25
-    )
-    .await;
+    // UNCOMMENT BELOW IF CONFIGURING A NEW GPS (saved to ROM)
+    // send_ubx_packet(
+    //     &mut gps2_uart,
+    //     0x06, // class: CFG
+    //     0x8A, // id: valset
+    //     &UBX_CFG_VALSET_10HZ_PAYLOAD,
+    //     "CFG-RATE-MEAS 10Hz", // update this if 25
+    // )
+    // .await;
 
     gps2_uart
 }


### PR DESCRIPTION
Adds 10Hz data output to F10 GPS, at 460800 baud.

**Note:** configuration of a new GPS is hard, you need to do the following:
1. Set baud rate in `sensorboard_rev1.rs` to gps baud (9600 m8, 38400 f10),
2. Send PUBX command to update baud rate
3. Re-configure baud rate in `sensorboard_rev1.rs`
4. Comment out baud rate reset
5. comment in send UBX command to update update rate
6. run
7. comment out ubx command for update rate, profit (unless using only per-use rate changes)

# Testing
<img width="865" height="868" alt="image" src="https://github.com/user-attachments/assets/a0f1c2c1-9c5f-408a-8431-1faace7a8c14" />
