### PR TITLE
Anni/sw/hard poll imu 100hz

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -14,6 +14,8 @@ bridge  = ["usb", "wifi"]
 hmi = []      # User LED, NeoPixel, Display
 imu = []      # IMU sensor (SPI)
 gps = []      # GPS sensor (UART)
+set_gps_high_baud = [] # Optional: configure GPS to high baudrate (non-default)
+set_gps_10hz = []      # Optional: configure GPS update rate to 10Hz (non-default)
 wifi = []     # WiFi/ESP-NOW wireless communication
 usb = []      # USB Serial for bridge data forwarding
 

--- a/sw/sensor_board/sensor_board_rev1_test/hirate_log.txt
+++ b/sw/sensor_board/sensor_board_rev1_test/hirate_log.txt
@@ -3,7 +3,7 @@ Crystal frequency: 40 MHz
 Flash size:        8MB
 Features:          WiFi 6, BT 5
 MAC address:       58:8c:81:40:be:0c
-App/part. size:    868,416/8,323,072 bytes, 10.43%
+App/part. size:    869,072/8,323,072 bytes, 10.44%
 Commands:
     CTRL+R    Reset chip
     CTRL+C    Exit
@@ -11,7 +11,7 @@ Commands:
 ESP-ROM:esp32c6-20220919
 Build:Sep 19 2022
 rst:0x15 (USB_UART_HPSYS),boot:0x3f (SPI_FAST_FLASH_BOOT)
-Saved PC:0x40800826
+Saved PC:0x40800822
 SPIWP:0xee
 mode:DIO, clock div:2
 load:0x40875730,len:0x175c
@@ -32,14 +32,14 @@ I (53) boot:  0 nvs              WiFi data        01 02 00009000 00006000
 I (59) boot:  1 phy_init         RF data          01 01 0000f000 00001000
 I (66) boot:  2 factory          factory app      00 00 00010000 007f0000
 I (72) boot: End of partition table
-I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=2e8ech (190700) map
-I (119) esp_image: segment 1: paddr=0003e914 vaddr=40800000 size=00014h (    20) load
-I (120) esp_image: segment 2: paddr=0003e930 vaddr=4202e930 size=92fd0h (602064) map
-I (238) esp_image: segment 3: paddr=000d1908 vaddr=40800014 size=0e628h ( 58920) load
-I (252) esp_image: segment 4: paddr=000dff38 vaddr=4080e640 size=03efch ( 16124) load
-I (256) esp_image: segment 5: paddr=000e3e3c vaddr=40812540 size=001e0h (   480) load
+I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=2e9f4h (190964) map
+I (119) esp_image: segment 1: paddr=0003ea1c vaddr=40800000 size=00014h (    20) load
+I (120) esp_image: segment 2: paddr=0003ea38 vaddr=4202ea38 size=93150h (602448) map
+I (238) esp_image: segment 3: paddr=000d1b90 vaddr=40800014 size=0e628h ( 58920) load
+I (252) esp_image: segment 4: paddr=000e01c0 vaddr=4080e640 size=03efch ( 16124) load
+I (256) esp_image: segment 5: paddr=000e40c4 vaddr=40812540 size=001e0h (   480) load
 I (261) boot: Loaded app from partition at offset 0x10000
-I (261) boot: Disabling RNG early entropy source...
+I (262) boot: Disabling RNG early entropy source...
 [32mINFO - Configuration complete - running app?[0m
 [32mINFO - baudrate for gps2_uart_set[0m
 [32mINFO - WiFi initialized successfully[0m
@@ -56,250 +56,452 @@ I (261) boot: Disabling RNG early entropy source...
 [32mINFO - IMU TASK BEING SPAWNED[0m
 [32mINFO - In imu task![0m
 [32mINFO - Attempting to read WHOAMI at reg: 0x0F[0m
-[32mINFO - [ESP-NOW TX] Heartbeat sent (time=364240us)[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=364707us)[0m
 [32mINFO - WhoAmI value is 0x6B[0m
 [32mINFO - IMU configured with BDU enabled[0m
-[32mINFO - TS: 25595623 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.540dps Z=-1.015dps[0m
-[32mINFO - TS: 25596166 Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.910dps[0m
-[32mINFO - TS: 25596696 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.770dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 25597231 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - TS: 25597765 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.525dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25598303 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69245628 (raw) / 0.009s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 69246166 (raw) / 0.022s Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.770dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69246708 (raw) / 0.035s Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 69247248 (raw) / 0.048s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.770dps[0m
+[32mINFO - TS: 69247786 (raw) / 0.061s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.750dps Z=-0.945dps[0m
+[32mINFO - t=0.064s GPS rmc time is: 2026-01-16 03:45:41 UTC[0m
+[32mINFO - t=0.065s GNVTG VELOCITY: Speed=0.03 knots (0.06 km/h); Heading: 0[0m
+[32mINFO - t=0.066s GPGGA FIX: Lat=43.473322333333336, Lon=-80.5366785, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69248332 (raw) / 0.074s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69248871 (raw) / 0.087s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69249411 (raw) / 0.100s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69249951 (raw) / 0.113s Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 69250488 (raw) / 0.126s Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.805dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 69251028 (raw) / 0.139s Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.420dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69251569 (raw) / 0.151s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - t=0.164s GPS rmc time is: 2026-01-16 03:45:41 UTC[0m
+[32mINFO - t=0.164s GNVTG VELOCITY: Speed=0.05 knots (0.08 km/h); Heading: 0[0m
+[32mINFO - t=0.166s GPGGA FIX: Lat=43.473322333333336, Lon=-80.5366785, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69252297 (raw) / 0.169s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 69252836 (raw) / 0.182s Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69253378 (raw) / 0.195s Accel: X=-0.052g Y=0.203g Z=0.987g Gyro: X=0.630dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 69253919 (raw) / 0.208s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69254455 (raw) / 0.221s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 69254996 (raw) / 0.234s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 69255536 (raw) / 0.247s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 69256078 (raw) / 0.260s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.295dps Z=-0.910dps[0m
+[32mINFO - t=0.264s GPS rmc time is: 2026-01-16 03:45:41 UTC[0m
+[32mINFO - t=0.265s GNVTG VELOCITY: Speed=0.09 knots (0.17 km/h); Heading: 0[0m
+[32mINFO - t=0.266s GPGGA FIX: Lat=43.4733225, Lon=-80.5366785, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69256625 (raw) / 0.273s Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.875dps[0m
+[32mINFO - TS: 69257170 (raw) / 0.286s Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.505dps Z=-0.980dps[0m
+[32mINFO - TS: 69257711 (raw) / 0.299s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69258252 (raw) / 0.312s Accel: X=-0.054g Y=0.200g Z=0.985g Gyro: X=0.700dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69258793 (raw) / 0.325s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 69259334 (raw) / 0.338s Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.770dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69259870 (raw) / 0.350s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.665dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 69260403 (raw) / 0.363s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69260941 (raw) / 0.376s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.490dps Y=-1.575dps Z=-0.910dps[0m
+[32mINFO - t=0.385s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=0.386s GNVTG VELOCITY: Speed=0.19 knots (0.34 km/h); Heading: 0[0m
+[32mINFO - t=0.387s GPGGA FIX: Lat=43.473322833333334, Lon=-80.53667766666666, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69261563 (raw) / 0.391s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69262116 (raw) / 0.404s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 69262651 (raw) / 0.417s Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.645dps Z=-0.875dps[0m
+[32mINFO - TS: 69263191 (raw) / 0.430s Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69263723 (raw) / 0.443s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 69264260 (raw) / 0.456s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - t=0.464s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=0.465s GNVTG VELOCITY: Speed=0.06 knots (0.11 km/h); Heading: 0[0m
+[32mINFO - t=0.466s GPGGA FIX: Lat=43.4733225, Lon=-80.53667833333333, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69264855 (raw) / 0.470s Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.980dps[0m
+[32mINFO - TS: 69265395 (raw) / 0.483s Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.805dps Y=-1.645dps Z=-0.770dps[0m
+[32mINFO - TS: 69265935 (raw) / 0.496s Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69266471 (raw) / 0.509s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69267010 (raw) / 0.522s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.770dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 69267551 (raw) / 0.535s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.945dps[0m
+[32mINFO - TS: 69268089 (raw) / 0.548s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.770dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69268626 (raw) / 0.560s Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - t=0.564s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=0.565s GNVTG VELOCITY: Speed=0.16 knots (0.30 km/h); Heading: 0[0m
+[32mINFO - t=0.566s GPGGA FIX: Lat=43.47332266666667, Lon=-80.53667766666666, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69269167 (raw) / 0.574s Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 69269727 (raw) / 0.587s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69270266 (raw) / 0.600s Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69270803 (raw) / 0.613s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 69271343 (raw) / 0.626s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.840dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69271876 (raw) / 0.638s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.630dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 69272412 (raw) / 0.651s Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - t=0.664s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=0.665s GNVTG VELOCITY: Speed=0.07 knots (0.13 km/h); Heading: 0[0m
+[32mINFO - t=0.666s GPGGA FIX: Lat=43.47332266666667, Lon=-80.53667783333333, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69273139 (raw) / 0.669s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69273696 (raw) / 0.682s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.365dps Z=-0.875dps[0m
+[32mINFO - TS: 69274237 (raw) / 0.695s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-1.015dps[0m
+[32mINFO - TS: 69274775 (raw) / 0.708s Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-1.015dps[0m
+[32mINFO - TS: 69275316 (raw) / 0.721s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.680dps Z=-0.875dps[0m
+[32mINFO - TS: 69275859 (raw) / 0.734s Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 69276400 (raw) / 0.747s Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 69276940 (raw) / 0.760s Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.680dps Z=-0.875dps[0m
+[32mINFO - t=0.764s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=0.765s GNVTG VELOCITY: Speed=0.13 knots (0.25 km/h); Heading: 0[0m
+[32mINFO - t=0.766s GPGGA FIX: Lat=43.47332266666667, Lon=-80.536678, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69277487 (raw) / 0.773s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 69278031 (raw) / 0.786s Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 69278568 (raw) / 0.799s Accel: X=-0.051g Y=0.201g Z=0.983g Gyro: X=0.700dps Y=-1.610dps Z=-0.980dps[0m
+[32mINFO - TS: 69279109 (raw) / 0.812s Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69279650 (raw) / 0.825s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69280191 (raw) / 0.838s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.735dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69280725 (raw) / 0.850s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - t=0.864s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=0.865s GNVTG VELOCITY: Speed=0.03 knots (0.06 km/h); Heading: 0[0m
+[32mINFO - t=0.866s GPGGA FIX: Lat=43.473322333333336, Lon=-80.53667883333334, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69281259 (raw) / 0.867s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69281967 (raw) / 0.880s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.455dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69282509 (raw) / 0.893s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69283050 (raw) / 0.906s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.400dps Z=-0.770dps[0m
+[32mINFO - TS: 69283589 (raw) / 0.919s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-1.015dps[0m
+[32mINFO - TS: 69284130 (raw) / 0.932s Accel: X=-0.052g Y=0.198g Z=0.986g Gyro: X=0.735dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 69284670 (raw) / 0.945s Accel: X=-0.052g Y=0.202g Z=0.984g Gyro: X=0.490dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69285211 (raw) / 0.958s Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - t=0.964s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=0.965s GNVTG VELOCITY: Speed=0.10 knots (0.19 km/h); Heading: 0[0m
+[32mINFO - t=0.966s GPGGA FIX: Lat=43.473322333333336, Lon=-80.53667883333334, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69285756 (raw) / 0.971s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69286328 (raw) / 0.985s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.610dps Z=-0.945dps[0m
+[32mINFO - TS: 69286865 (raw) / 0.998s Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=1367840us)[0m
+[32mINFO - TS: 69287406 (raw) / 1.011s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.665dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 69287940 (raw) / 1.023s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69288480 (raw) / 1.036s Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.700dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 69289018 (raw) / 1.049s Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.610dps Z=-0.945dps[0m
+[32mINFO - TS: 69289559 (raw) / 1.062s Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.400dps Z=-0.805dps[0m
+[32mINFO - t=1.064s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=1.065s GNVTG VELOCITY: Speed=0.14 knots (0.26 km/h); Heading: 0[0m
+[32mINFO - t=1.066s GPGGA FIX: Lat=43.47332216666667, Lon=-80.536679, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69290103 (raw) / 1.075s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 69290643 (raw) / 1.088s Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.770dps[0m
+[32mINFO - TS: 69291177 (raw) / 1.101s Accel: X=-0.053g Y=0.202g Z=0.985g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69291717 (raw) / 1.114s Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69292260 (raw) / 1.127s Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69292798 (raw) / 1.140s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.400dps Z=-0.980dps[0m
+[32mINFO - TS: 69293339 (raw) / 1.153s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.770dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - t=1.164s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=1.165s GNVTG VELOCITY: Speed=0.15 knots (0.28 km/h); Heading: 0[0m
+[32mINFO - t=1.166s GPGGA FIX: Lat=43.473322, Lon=-80.536679, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69294059 (raw) / 1.170s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.805dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69294599 (raw) / 1.183s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69295135 (raw) / 1.196s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 69295676 (raw) / 1.209s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 69296217 (raw) / 1.222s Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.560dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 69296755 (raw) / 1.235s Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69297292 (raw) / 1.248s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 69297830 (raw) / 1.260s Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - t=1.264s GPS rmc time is: 2026-01-16 03:45:42 UTC[0m
+[32mINFO - t=1.265s GNVTG VELOCITY: Speed=0.14 knots (0.25 km/h); Heading: 0[0m
+[32mINFO - t=1.266s GPGGA FIX: Lat=43.47332166666666, Lon=-80.53668, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69298374 (raw) / 1.274s Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.805dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69298910 (raw) / 1.286s Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.455dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69299444 (raw) / 1.299s Accel: X=-0.053g Y=0.199g Z=0.985g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69299985 (raw) / 1.312s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 69300522 (raw) / 1.325s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69301062 (raw) / 1.338s Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 69301600 (raw) / 1.351s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 69302142 (raw) / 1.364s Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.700dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 69302684 (raw) / 1.377s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.610dps Z=-0.805dps[0m
+[32mINFO - t=1.385s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=1.386s GNVTG VELOCITY: Speed=0.23 knots (0.43 km/h); Heading: 0[0m
+[32mINFO - t=1.388s GPGGA FIX: Lat=43.47332133333333, Lon=-80.5366805, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69303278 (raw) / 1.391s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69303838 (raw) / 1.405s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69304375 (raw) / 1.417s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 69304913 (raw) / 1.430s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.400dps Z=-0.980dps[0m
+[32mINFO - TS: 69305453 (raw) / 1.443s Accel: X=-0.053g Y=0.202g Z=0.985g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69305992 (raw) / 1.456s Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - t=1.465s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=1.466s GNVTG VELOCITY: Speed=0.28 knots (0.51 km/h); Heading: 0[0m
+[32mINFO - t=1.467s GPGGA FIX: Lat=43.473321166666665, Lon=-80.53668083333334, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69306604 (raw) / 1.471s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.610dps Z=-0.805dps[0m
+[32mINFO - TS: 69307159 (raw) / 1.484s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.770dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69307695 (raw) / 1.497s Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69308237 (raw) / 1.510s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69308776 (raw) / 1.523s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 69309317 (raw) / 1.536s Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.595dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 69309851 (raw) / 1.549s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.770dps Y=-1.330dps Z=-0.735dps[0m
+[32mINFO - TS: 69310393 (raw) / 1.562s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.770dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - t=1.564s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=1.565s GNVTG VELOCITY: Speed=0.12 knots (0.23 km/h); Heading: 0[0m
+[32mINFO - t=1.566s GPGGA FIX: Lat=43.473321166666665, Lon=-80.53668083333334, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69310932 (raw) / 1.575s Accel: X=-0.053g Y=0.198g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.980dps[0m
+[32mINFO - TS: 69311468 (raw) / 1.587s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 69312008 (raw) / 1.600s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.645dps Z=-0.910dps[0m
+[32mINFO - TS: 69312548 (raw) / 1.613s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 69313084 (raw) / 1.626s Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.945dps[0m
+[32mINFO - TS: 69313620 (raw) / 1.639s Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.490dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69314160 (raw) / 1.652s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - t=1.664s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=1.665s GNVTG VELOCITY: Speed=0.06 knots (0.11 km/h); Heading: 0[0m
+[32mINFO - t=1.666s GPGGA FIX: Lat=43.4733215, Lon=-80.53668, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69314880 (raw) / 1.669s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 69315435 (raw) / 1.683s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 69315967 (raw) / 1.695s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.665dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69316507 (raw) / 1.708s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 69317045 (raw) / 1.721s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 69317586 (raw) / 1.734s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 69318125 (raw) / 1.747s Accel: X=-0.054g Y=0.200g Z=0.985g Gyro: X=0.490dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 69318665 (raw) / 1.760s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - t=1.764s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=1.765s GNVTG VELOCITY: Speed=0.14 knots (0.26 km/h); Heading: 0[0m
+[32mINFO - t=1.766s GPGGA FIX: Lat=43.473321166666665, Lon=-80.53668066666667, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69319211 (raw) / 1.773s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 69319750 (raw) / 1.786s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 69320293 (raw) / 1.799s Accel: X=-0.051g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 69320835 (raw) / 1.812s Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.490dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 69321372 (raw) / 1.825s Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.595dps Y=-1.400dps Z=-0.875dps[0m
+[32mINFO - TS: 69321910 (raw) / 1.838s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.525dps Y=-1.435dps Z=-1.015dps[0m
+[32mINFO - TS: 69322445 (raw) / 1.851s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - t=1.864s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=1.865s GNVTG VELOCITY: Speed=0.07 knots (0.13 km/h); Heading: 0[0m
+[32mINFO - t=1.866s GPGGA FIX: Lat=43.473321166666665, Lon=-80.53668116666667, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69323167 (raw) / 1.868s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69323713 (raw) / 1.881s Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69324255 (raw) / 1.894s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 69324796 (raw) / 1.907s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69325337 (raw) / 1.920s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69325879 (raw) / 1.933s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69326421 (raw) / 1.946s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69326958 (raw) / 1.959s Accel: X=-0.052g Y=0.199g Z=0.989g Gyro: X=0.525dps Y=-1.610dps Z=-0.945dps[0m
+[32mINFO - t=1.964s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=1.965s GNVTG VELOCITY: Speed=0.14 knots (0.27 km/h); Heading: 0[0m
+[32mINFO - t=1.966s GPGGA FIX: Lat=43.47332083333333, Lon=-80.53668133333333, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69327499 (raw) / 1.972s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69328040 (raw) / 1.985s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 69328583 (raw) / 1.998s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.700dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=2371122us)[0m
+[32mINFO - TS: 69329124 (raw) / 2.011s Accel: X=-0.052g Y=0.198g Z=0.985g Gyro: X=0.560dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69329670 (raw) / 2.024s Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.595dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 69330204 (raw) / 2.037s Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 69330737 (raw) / 2.049s Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 69331274 (raw) / 2.062s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.525dps Y=-1.435dps Z=-0.875dps[0m
 [31mERROR - UART Read Error: FifoOverflowed[0m
 [31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: .0,M,,*74 for sentence: '.0,M,,*74'[0m
-[32mINFO - TS: 25598840 Accel: X=-0.051g Y=0.198g Z=0.987g Gyro: X=0.525dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25599374 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.470dps Z=-0.770dps[0m
-[32mINFO - TS: 25599911 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.910dps[0m
-[32mINFO - TS: 25600445 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.575dps Z=-0.980dps[0m
-[32mINFO - TS: 25600984 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
-[32mINFO - TS: 25601521 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-1.050dps[0m
-[32mINFO - TS: 25602055 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.295dps Z=-0.945dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.11 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670866666667, HDOP=2.05, SATS=8[0m
-[32mINFO - TS: 25602750 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25603292 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - TS: 25603828 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.645dps Z=-0.910dps[0m
-[32mINFO - TS: 25604371 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 25604907 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 25605437 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 25605961 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25606507 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.09 knots (0.17 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331766666667, Lon=-80.53670916666667, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25607050 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.770dps[0m
-[32mINFO - TS: 25607584 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25608121 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 25608658 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.805dps[0m
-[32mINFO - TS: 25609196 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 25609730 Accel: X=-0.055g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.805dps[0m
-[32mINFO - TS: 25610263 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 25610797 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.400dps Z=-0.805dps[0m
+[32mINFO - TS: 69331818 (raw) / 2.075s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 69332359 (raw) / 2.088s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 69332895 (raw) / 2.101s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69333433 (raw) / 2.114s Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69333974 (raw) / 2.127s Accel: X=-0.052g Y=0.199g Z=0.989g Gyro: X=0.595dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 69334511 (raw) / 2.140s Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69335051 (raw) / 2.153s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - t=2.163s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=2.164s GNVTG VELOCITY: Speed=0.08 knots (0.15 km/h); Heading: 0[0m
+[32mINFO - t=2.165s GPGGA FIX: Lat=43.473321, Lon=-80.5366815, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69335710 (raw) / 2.169s Accel: X=-0.051g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69336256 (raw) / 2.182s Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.700dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 69336793 (raw) / 2.195s Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.560dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 69337332 (raw) / 2.207s Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.770dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69337871 (raw) / 2.220s Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.770dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69338412 (raw) / 2.233s Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69338945 (raw) / 2.246s Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 69339481 (raw) / 2.259s Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - t=2.264s GPS rmc time is: 2026-01-16 03:45:43 UTC[0m
+[32mINFO - t=2.265s GNVTG VELOCITY: Speed=0.11 knots (0.20 km/h); Heading: 0[0m
+[32mINFO - t=2.267s GPGGA FIX: Lat=43.47332133333333, Lon=-80.536681, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69340041 (raw) / 2.272s Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 69340586 (raw) / 2.285s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 69341126 (raw) / 2.298s Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.665dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 69341666 (raw) / 2.311s Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69342201 (raw) / 2.324s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 69342739 (raw) / 2.337s Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69343274 (raw) / 2.350s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69343811 (raw) / 2.363s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 69344352 (raw) / 2.376s Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - t=2.379s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=2.380s GNVTG VELOCITY: Speed=0.15 knots (0.28 km/h); Heading: 0[0m
+[32mINFO - t=2.382s GPGGA FIX: Lat=43.47332133333333, Lon=-80.536681, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69344900 (raw) / 2.389s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 69345445 (raw) / 2.402s Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.400dps Z=-1.015dps[0m
+[32mINFO - TS: 69345983 (raw) / 2.415s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 69346524 (raw) / 2.428s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69347066 (raw) / 2.441s Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.770dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 69347606 (raw) / 2.454s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.365dps Z=-0.875dps[0m
+[32mINFO - t=2.464s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=2.465s GNVTG VELOCITY: Speed=0.06 knots (0.12 km/h); Heading: 0[0m
+[32mINFO - t=2.466s GPGGA FIX: Lat=43.473321, Lon=-80.536682, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69348265 (raw) / 2.470s Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.490dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 69348819 (raw) / 2.483s Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.805dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69349359 (raw) / 2.496s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.875dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69349897 (raw) / 2.509s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 69350433 (raw) / 2.522s Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.560dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69350974 (raw) / 2.535s Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.560dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 69351508 (raw) / 2.547s Accel: X=-0.053g Y=0.199g Z=0.985g Gyro: X=0.735dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69352049 (raw) / 2.560s Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.645dps Z=-0.840dps[0m
+[32mINFO - t=2.566s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=2.567s GNVTG VELOCITY: Speed=0.04 knots (0.08 km/h); Heading: 0[0m
+[32mINFO - t=2.569s GPGGA FIX: Lat=43.473321166666665, Lon=-80.5366815, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69352609 (raw) / 2.574s Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 69353155 (raw) / 2.587s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69353699 (raw) / 2.600s Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69354240 (raw) / 2.613s Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.700dps[0m
+[32mINFO - TS: 69354782 (raw) / 2.626s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 69355324 (raw) / 2.639s Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 69355863 (raw) / 2.652s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - t=2.663s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=2.664s GNVTG VELOCITY: Speed=0.11 knots (0.20 km/h); Heading: 0[0m
+[32mINFO - t=2.665s GPGGA FIX: Lat=43.4733215, Lon=-80.53668133333333, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69356563 (raw) / 2.668s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.735dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69357118 (raw) / 2.682s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.770dps Y=-1.610dps Z=-0.805dps[0m
+[32mINFO - TS: 69357655 (raw) / 2.695s Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.910dps[0m
+[32mINFO - TS: 69358188 (raw) / 2.707s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.770dps Y=-1.610dps Z=-0.945dps[0m
+[32mINFO - TS: 69358728 (raw) / 2.720s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.840dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 69359263 (raw) / 2.733s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69359802 (raw) / 2.746s Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 69360343 (raw) / 2.759s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - t=2.766s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=2.767s GNVTG VELOCITY: Speed=0.22 knots (0.40 km/h); Heading: 0[0m
+[32mINFO - t=2.768s GPGGA FIX: Lat=43.473322, Lon=-80.5366805, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69360910 (raw) / 2.773s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.770dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69361448 (raw) / 2.786s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 69361980 (raw) / 2.798s Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 69362521 (raw) / 2.811s Accel: X=-0.054g Y=0.201g Z=0.985g Gyro: X=0.560dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 69363056 (raw) / 2.824s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 69363597 (raw) / 2.837s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 69364136 (raw) / 2.850s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.735dps[0m
+[32mINFO - t=2.864s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=2.865s GNVTG VELOCITY: Speed=0.10 knots (0.19 km/h); Heading: 0[0m
+[32mINFO - t=2.866s GPGGA FIX: Lat=43.47332216666667, Lon=-80.5366805, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69364673 (raw) / 2.868s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.645dps Z=-0.875dps[0m
+[32mINFO - TS: 69365425 (raw) / 2.881s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69365966 (raw) / 2.894s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69366507 (raw) / 2.907s Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69367048 (raw) / 2.920s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 69367590 (raw) / 2.933s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 69368128 (raw) / 2.946s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 69368666 (raw) / 2.959s Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.735dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - t=2.964s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=2.965s GNVTG VELOCITY: Speed=0.31 knots (0.57 km/h); Heading: 0[0m
+[32mINFO - t=2.966s GPGGA FIX: Lat=43.473322333333336, Lon=-80.53668033333334, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69369216 (raw) / 2.972s Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69369753 (raw) / 2.985s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.280dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 69370286 (raw) / 2.997s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.735dps[0m
+[32mINFO - TS: 69370822 (raw) / 3.010s Accel: X=-0.054g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=3376757us)[0m
+[32mINFO - TS: 69371368 (raw) / 3.023s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 69371907 (raw) / 3.036s Accel: X=-0.055g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.365dps Z=-0.945dps[0m
+[32mINFO - TS: 69372442 (raw) / 3.049s Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 69372980 (raw) / 3.062s Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - t=3.066s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=3.067s GNVTG VELOCITY: Speed=0.10 knots (0.19 km/h); Heading: 0[0m
+[32mINFO - t=3.069s GPGGA FIX: Lat=43.473322, Lon=-80.536681, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69373533 (raw) / 3.075s Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.665dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 69374073 (raw) / 3.088s Accel: X=-0.054g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69374615 (raw) / 3.101s Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.595dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 69375154 (raw) / 3.114s Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69375696 (raw) / 3.127s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.770dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69376237 (raw) / 3.140s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 69376774 (raw) / 3.153s Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - t=3.163s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=3.164s GNVTG VELOCITY: Speed=0.12 knots (0.22 km/h); Heading: 0[0m
+[32mINFO - t=3.166s GPGGA FIX: Lat=43.47332216666667, Lon=-80.536681, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69377455 (raw) / 3.169s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.610dps Z=-0.700dps[0m
+[32mINFO - TS: 69378011 (raw) / 3.183s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 69378543 (raw) / 3.195s Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 69379080 (raw) / 3.208s Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 69379616 (raw) / 3.221s Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 69380153 (raw) / 3.234s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.610dps Z=-0.980dps[0m
+[32mINFO - TS: 69380692 (raw) / 3.247s Accel: X=-0.054g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69381227 (raw) / 3.260s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - t=3.264s GPS rmc time is: 2026-01-16 03:45:44 UTC[0m
+[32mINFO - t=3.265s GNVTG VELOCITY: Speed=0.19 knots (0.35 km/h); Heading: 0[0m
+[32mINFO - t=3.266s GPGGA FIX: Lat=43.47332216666667, Lon=-80.53668083333334, HDOP=1.65, SATS=9[0m
+[32mINFO - TS: 69381771 (raw) / 3.273s Accel: X=-0.052g Y=0.200g Z=0.984g Gyro: X=0.560dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 69382314 (raw) / 3.286s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69382853 (raw) / 3.299s Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 69383392 (raw) / 3.312s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69383931 (raw) / 3.325s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.735dps[0m
+[32mINFO - TS: 69384469 (raw) / 3.337s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.980dps[0m
+[32mINFO - TS: 69385009 (raw) / 3.350s Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.435dps Z=-0.980dps[0m
+[32mINFO - TS: 69385551 (raw) / 3.363s Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.525dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69386093 (raw) / 3.376s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.805dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - t=3.382s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=3.383s GNVTG VELOCITY: Speed=0.16 knots (0.29 km/h); Heading: 0[0m
+[32mINFO - t=3.384s GPGGA FIX: Lat=43.473322, Lon=-80.53668116666667, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69386638 (raw) / 3.389s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 69387180 (raw) / 3.402s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69387716 (raw) / 3.415s Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.525dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69388256 (raw) / 3.428s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 69388796 (raw) / 3.441s Accel: X=-0.053g Y=0.201g Z=0.984g Gyro: X=0.665dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 69389332 (raw) / 3.454s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - t=3.464s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=3.465s GNVTG VELOCITY: Speed=0.17 knots (0.32 km/h); Heading: 0[0m
+[32mINFO - t=3.466s GPGGA FIX: Lat=43.473322, Lon=-80.53668133333333, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69389982 (raw) / 3.470s Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 69390537 (raw) / 3.483s Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.645dps Z=-0.910dps[0m
+[32mINFO - TS: 69391077 (raw) / 3.496s Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.630dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69391611 (raw) / 3.509s Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.700dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 69392148 (raw) / 3.522s Accel: X=-0.054g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.700dps[0m
+[32mINFO - TS: 69392689 (raw) / 3.535s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 69393222 (raw) / 3.547s Accel: X=-0.051g Y=0.198g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69393762 (raw) / 3.560s Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.595dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - t=3.564s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=3.565s GNVTG VELOCITY: Speed=0.17 knots (0.33 km/h); Heading: 0[0m
+[32mINFO - t=3.567s GPGGA FIX: Lat=43.47332216666667, Lon=-80.53668116666667, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69394314 (raw) / 3.573s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.805dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 69394857 (raw) / 3.586s Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69395397 (raw) / 3.599s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.840dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69395934 (raw) / 3.612s Accel: X=-0.054g Y=0.199g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 69396471 (raw) / 3.625s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69397013 (raw) / 3.638s Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.735dps Y=-1.365dps Z=-0.805dps[0m
+[32mINFO - TS: 69397555 (raw) / 3.651s Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.560dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - t=3.663s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=3.664s GNVTG VELOCITY: Speed=0.04 knots (0.07 km/h); Heading: 0[0m
+[32mINFO - t=3.666s GPGGA FIX: Lat=43.47332183333333, Lon=-80.53668216666667, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69398304 (raw) / 3.669s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.805dps Y=-1.610dps Z=-0.805dps[0m
+[32mINFO - TS: 69398851 (raw) / 3.682s Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 69399389 (raw) / 3.695s Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.700dps Y=-1.435dps Z=-0.980dps[0m
+[32mINFO - TS: 69399931 (raw) / 3.708s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69400471 (raw) / 3.721s Accel: X=-0.052g Y=0.201g Z=0.990g Gyro: X=0.630dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 69401007 (raw) / 3.734s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 69401539 (raw) / 3.747s Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69402076 (raw) / 3.760s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - t=3.764s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=3.765s GNVTG VELOCITY: Speed=0.18 knots (0.34 km/h); Heading: 0[0m
+[32mINFO - t=3.766s GPGGA FIX: Lat=43.47332183333333, Lon=-80.53668216666667, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69402617 (raw) / 3.773s Accel: X=-0.053g Y=0.200g Z=0.984g Gyro: X=0.595dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69403158 (raw) / 3.786s Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 69403700 (raw) / 3.799s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.805dps[0m
+[32mINFO - TS: 69404242 (raw) / 3.811s Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69404785 (raw) / 3.825s Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69405326 (raw) / 3.837s Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.645dps Z=-0.910dps[0m
+[32mINFO - TS: 69405868 (raw) / 3.850s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - t=3.864s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=3.865s GNVTG VELOCITY: Speed=0.12 knots (0.23 km/h); Heading: 0[0m
+[32mINFO - t=3.866s GPGGA FIX: Lat=43.47332183333333, Lon=-80.536682, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69406577 (raw) / 3.868s Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69407137 (raw) / 3.881s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.700dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 69407671 (raw) / 3.894s Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 69408211 (raw) / 3.907s Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 69408749 (raw) / 3.920s Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 69409285 (raw) / 3.932s Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.770dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 69409826 (raw) / 3.945s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.610dps Z=-0.945dps[0m
+[32mINFO - TS: 69410365 (raw) / 3.958s Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - t=3.964s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=3.965s GNVTG VELOCITY: Speed=0.12 knots (0.21 km/h); Heading: 0[0m
+[32mINFO - t=3.967s GPGGA FIX: Lat=43.473322, Lon=-80.53668233333333, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69410930 (raw) / 3.972s Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 69411473 (raw) / 3.985s Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.770dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69412006 (raw) / 3.998s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.910dps[0m
+[32mINFO - TS: 69412542 (raw) / 4.010s Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=4378053us)[0m
+[32mINFO - TS: 69413082 (raw) / 4.023s Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.805dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 69413623 (raw) / 4.036s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.805dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 69414164 (raw) / 4.049s Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.770dps Y=-1.610dps Z=-0.735dps[0m
+[32mINFO - TS: 69414706 (raw) / 4.062s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.505dps Z=-0.840dps[0m
 [31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: 8032.20254,W,2,09,1.80,386.1,M,-36.0,M,,*7C for sentence: '8032.20254,W,2,09,1.80,386.1,M,-36.0,M,,*7C'[0m
-[32mINFO - TS: 25611330 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25611863 Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 25612403 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.805dps[0m
-[32mINFO - TS: 25612937 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 25613475 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - TS: 25614006 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25614545 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.19 knots (0.35 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331766666667, Lon=-80.536709, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25615237 Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25615774 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 25616319 Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.330dps Z=-0.875dps[0m
-[32mINFO - TS: 25616858 Accel: X=-0.050g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - TS: 25617396 Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.575dps Z=-0.700dps[0m
-[32mINFO - TS: 25617930 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
-[32mINFO - TS: 25618466 Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.575dps Z=-0.945dps[0m
-[32mINFO - TS: 25618996 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.19 knots (0.36 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670916666667, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25619561 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - TS: 25620101 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.595dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25620631 Accel: X=-0.051g Y=0.198g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.910dps[0m
-[32mINFO - TS: 25621167 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - TS: 25621700 Accel: X=-0.050g Y=0.202g Z=0.989g Gyro: X=0.560dps Y=-1.575dps Z=-0.910dps[0m
-[32mINFO - TS: 25622238 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.365dps Z=-0.945dps[0m
-[32mINFO - TS: 25622767 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 25623305 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.11 knots (0.20 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670883333334, HDOP=2.05, SATS=8[0m
-[32mINFO - TS: 25623846 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.420dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 25624386 Accel: X=-0.054g Y=0.202g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25624924 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.400dps Z=-0.840dps[0m
-[32mINFO - TS: 25625458 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25625996 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.365dps Z=-0.840dps[0m
-[32mINFO - TS: 25626533 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.490dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 25627068 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 25627603 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 25628143 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.12 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473318, Lon=-80.53670866666667, HDOP=2.05, SATS=8[0m
-[32mINFO - TS: 25628686 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.575dps Z=-0.980dps[0m
-[32mINFO - TS: 25629220 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25629753 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 25630291 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 25630822 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 25631358 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.14 knots (0.27 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473318, Lon=-80.5367085, HDOP=2.05, SATS=8[0m
-[32mINFO - TS: 25632012 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 25632559 Accel: X=-0.052g Y=0.203g Z=0.986g Gyro: X=0.595dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 25633094 Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 25633627 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25634161 Accel: X=-0.054g Y=0.202g Z=0.988g Gyro: X=0.735dps Y=-1.610dps Z=-0.840dps[0m
-[32mINFO - TS: 25634692 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.575dps Z=-0.910dps[0m
-[32mINFO - TS: 25635224 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.805dps Y=-1.400dps Z=-0.875dps[0m
-[32mINFO - TS: 25635761 Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.735dps Y=-1.365dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.13 knots (0.24 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473318166666665, Lon=-80.53670833333334, HDOP=2.05, SATS=8[0m
-[32mINFO - TS: 25636304 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 25636840 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-1.015dps[0m
-[32mINFO - [ESP-NOW TX] Heartbeat sent (time=1367320us)[0m
-[32mINFO - TS: 25637381 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 25637916 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 25638452 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.770dps[0m
-[32mINFO - TS: 25638985 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 25639524 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.575dps Z=-0.770dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.08 knots (0.14 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473318, Lon=-80.53670816666667, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25640057 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - TS: 25640778 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 25641318 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.470dps Z=-0.805dps[0m
-[32mINFO - TS: 25641850 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.770dps[0m
-[32mINFO - TS: 25642381 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - TS: 25642916 Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 25643449 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - TS: 25643981 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.11 knots (0.20 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670833333334, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25644572 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 25645115 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 25645649 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.805dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 25646187 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.770dps Y=-1.505dps Z=-0.980dps[0m
-[32mINFO - TS: 25646724 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.525dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 25647254 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
-[32mINFO - TS: 25647785 Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.645dps Z=-0.840dps[0m
-[32mINFO - TS: 25648323 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.490dps Y=-1.540dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.09 knots (0.16 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.5367085, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25648866 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 25649409 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 25649948 Accel: X=-0.053g Y=0.200g Z=0.989g Gyro: X=0.840dps Y=-1.435dps Z=-0.980dps[0m
-[32mINFO - TS: 25650486 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.840dps Y=-1.540dps Z=-0.700dps[0m
-[32mINFO - TS: 25651018 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 25651553 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.770dps Y=-1.435dps Z=-0.805dps[0m
-[32mINFO - TS: 25652091 Accel: X=-0.051g Y=0.201g Z=0.989g Gyro: X=0.630dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.24 knots (0.44 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670883333334, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25652807 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 25653348 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.910dps[0m
-[32mINFO - TS: 25653882 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.910dps[0m
-[32mINFO - TS: 25654419 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 25654958 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 25655491 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - TS: 25656030 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.680dps Z=-0.770dps[0m
-[32mINFO - TS: 25656564 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.680dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.22 knots (0.41 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331833333333, Lon=-80.53670816666667, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25657158 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.735dps[0m
-[32mINFO - TS: 25657694 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 25658228 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 25658765 Accel: X=-0.054g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-1.015dps[0m
-[32mINFO - TS: 25659302 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 25659836 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25660367 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25660897 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.14 knots (0.25 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473318166666665, Lon=-80.53670833333334, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25661440 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25661982 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 25662521 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25663052 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.560dps Y=-1.400dps Z=-0.840dps[0m
-[32mINFO - TS: 25663586 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.560dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25664117 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25664647 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.610dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.15 knots (0.28 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670833333334, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25665381 Accel: X=-0.053g Y=0.199g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 25665936 Accel: X=-0.053g Y=0.201g Z=0.989g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 25666473 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 25667012 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.770dps[0m
-[32mINFO - TS: 25667549 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 25668087 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.525dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25668622 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.435dps Z=-0.805dps[0m
-[32mINFO - TS: 25669157 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25669695 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.610dps Z=-0.770dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.08 knots (0.15 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331833333333, Lon=-80.53670783333334, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25670323 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.945dps[0m
-[32mINFO - TS: 25670862 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 25671399 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 25671934 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.735dps Y=-1.400dps Z=-0.945dps[0m
-[32mINFO - TS: 25672471 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 25673009 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.525dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.31 knots (0.58 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473318166666665, Lon=-80.5367085, HDOP=1.8, SATS=9[0m
-[32mINFO - TS: 25673719 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.455dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 25674275 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 25674811 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 25675344 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.700dps[0m
-[32mINFO - TS: 25675878 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 25676414 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 25676949 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 25677486 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.770dps[0m
 [31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: N,08032.20250,W,2,09,1.80,386.3,M,-36.0,M,,*72 for sentence: 'N,08032.20250,W,2,09,1.80,386.3,M,-36.0,M,,*72'[0m
-[32mINFO - TS: 25678021 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.525dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 25678561 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - [ESP-NOW TX] Heartbeat sent (time=2369161us)[0m
-[32mINFO - TS: 25679103 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 25679633 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 25680165 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.435dps Z=-0.910dps[0m
-[32mINFO - TS: 25680697 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
-[32mINFO - TS: 25681230 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - TS: 25681760 Accel: X=-0.055g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.875dps[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: 36.0,M,,*76 for sentence: '36.0,M,,*76'[0m
-[32mINFO - TS: 25682301 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 25682841 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 25683379 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 25683917 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 25684456 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.770dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 25684994 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.770dps[0m
-[32mINFO - TS: 25685532 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:28:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.23 knots (0.43 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47331883333333, Lon=-80.536707, HDOP=1.8, SATS=10[0m
-[32mINFO - TS: 25686247 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-1.015dps[0m
-[32mINFO - TS: 25686790 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.610dps Z=-0.770dps[0m
-[32mINFO - TS: 25687329 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 25687867 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.575dps Z=-0.735dps[0m
-[32mINFO - TS: 25688406 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.840dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 25688941 Accel: X=-0.051g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 25689472 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.770dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 25690008 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.910dps[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: 08032.20238,W,2,10,1.80,386.0,M,-36.0,M,,*7C for sentence: '08032.20238,W,2,10,1.80,386.0,M,-36.0,M,,*7C'[0m
-[32mINFO - TS: 25690545 Accel: X=-0.053g Y=0.203g Z=0.987g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 25691085 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.980dps[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: 0,M,,*72 for sentence: '0,M,,*72'[0m
+[32mINFO - TS: 69415247 (raw) / 4.075s Accel: X=-0.054g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 69415789 (raw) / 4.088s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69416331 (raw) / 4.101s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 69416874 (raw) / 4.114s Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69417416 (raw) / 4.127s Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69417957 (raw) / 4.140s Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 69418499 (raw) / 4.153s Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - t=4.164s GPS rmc time is: 2026-01-16 03:45:45 UTC[0m
+[32mINFO - t=4.165s GNVTG VELOCITY: Speed=0.03 knots (0.06 km/h); Heading: 0[0m
+[32mINFO - t=4.166s GPGGA FIX: Lat=43.473322, Lon=-80.53668283333333, HDOP=1.64, SATS=10[0m
+[32mINFO - TS: 69419196 (raw) / 4.170s Accel: X=-0.0

--- a/sw/sensor_board/sensor_board_rev1_test/hirate_log.txt
+++ b/sw/sensor_board/sensor_board_rev1_test/hirate_log.txt
@@ -3,7 +3,7 @@ Crystal frequency: 40 MHz
 Flash size:        8MB
 Features:          WiFi 6, BT 5
 MAC address:       58:8c:81:40:be:0c
-App/part. size:    866,992/8,323,072 bytes, 10.42%
+App/part. size:    868,416/8,323,072 bytes, 10.43%
 Commands:
     CTRL+R    Reset chip
     CTRL+C    Exit
@@ -11,7 +11,7 @@ Commands:
 ESP-ROM:esp32c6-20220919
 Build:Sep 19 2022
 rst:0x15 (USB_UART_HPSYS),boot:0x3f (SPI_FAST_FLASH_BOOT)
-Saved PC:0x40800822
+Saved PC:0x40800826
 SPIWP:0xee
 mode:DIO, clock div:2
 load:0x40875730,len:0x175c
@@ -32,12 +32,12 @@ I (53) boot:  0 nvs              WiFi data        01 02 00009000 00006000
 I (59) boot:  1 phy_init         RF data          01 01 0000f000 00001000
 I (66) boot:  2 factory          factory app      00 00 00010000 007f0000
 I (72) boot: End of partition table
-I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=2e8b4h (190644) map
-I (119) esp_image: segment 1: paddr=0003e8dc vaddr=40800000 size=00014h (    20) load
-I (120) esp_image: segment 2: paddr=0003e8f8 vaddr=4202e8f8 size=92a6ch (600684) map
-I (238) esp_image: segment 3: paddr=000d136c vaddr=40800014 size=0e628h ( 58920) load
-I (252) esp_image: segment 4: paddr=000df99c vaddr=4080e640 size=03efch ( 16124) load
-I (256) esp_image: segment 5: paddr=000e38a0 vaddr=40812540 size=001e0h (   480) load
+I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=2e8ech (190700) map
+I (119) esp_image: segment 1: paddr=0003e914 vaddr=40800000 size=00014h (    20) load
+I (120) esp_image: segment 2: paddr=0003e930 vaddr=4202e930 size=92fd0h (602064) map
+I (238) esp_image: segment 3: paddr=000d1908 vaddr=40800014 size=0e628h ( 58920) load
+I (252) esp_image: segment 4: paddr=000dff38 vaddr=4080e640 size=03efch ( 16124) load
+I (256) esp_image: segment 5: paddr=000e3e3c vaddr=40812540 size=001e0h (   480) load
 I (261) boot: Loaded app from partition at offset 0x10000
 I (261) boot: Disabling RNG early entropy source...
 [32mINFO - Configuration complete - running app?[0m
@@ -56,425 +56,250 @@ I (261) boot: Disabling RNG early entropy source...
 [32mINFO - IMU TASK BEING SPAWNED[0m
 [32mINFO - In imu task![0m
 [32mINFO - Attempting to read WHOAMI at reg: 0x0F[0m
-[32mINFO - [ESP-NOW TX] Heartbeat sent (time=363609us)[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=364240us)[0m
 [32mINFO - WhoAmI value is 0x6B[0m
-[32mINFO - Timestamp enabled[0m
-[32mINFO - TS: 8073196 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8073735 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.08 knots (0.14 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329366666666, Lon=-80.53687566666666, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8074376 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8074922 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8075460 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8076000 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.700dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8076537 Accel: X=-0.053g Y=0.201g Z=0.989g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8077074 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.945dps[0m
-[32mINFO - TS: 8077604 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8078142 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - IMU configured with BDU enabled[0m
+[32mINFO - TS: 25595623 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.540dps Z=-1.015dps[0m
+[32mINFO - TS: 25596166 Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 25596696 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.770dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 25597231 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 25597765 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.525dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25598303 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: .0,M,,*74 for sentence: '.0,M,,*74'[0m
+[32mINFO - TS: 25598840 Accel: X=-0.051g Y=0.198g Z=0.987g Gyro: X=0.525dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25599374 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 25599911 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.910dps[0m
+[32mINFO - TS: 25600445 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.575dps Z=-0.980dps[0m
+[32mINFO - TS: 25600984 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 25601521 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-1.050dps[0m
+[32mINFO - TS: 25602055 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.295dps Z=-0.945dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.11 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670866666667, HDOP=2.05, SATS=8[0m
+[32mINFO - TS: 25602750 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25603292 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 25603828 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.645dps Z=-0.910dps[0m
+[32mINFO - TS: 25604371 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 25604907 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 25605437 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 25605961 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25606507 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.09 knots (0.17 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331766666667, Lon=-80.53670916666667, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25607050 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.770dps[0m
+[32mINFO - TS: 25607584 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25608121 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 25608658 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 25609196 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 25609730 Accel: X=-0.055g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 25610263 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 25610797 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.400dps Z=-0.805dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: 8032.20254,W,2,09,1.80,386.1,M,-36.0,M,,*7C for sentence: '8032.20254,W,2,09,1.80,386.1,M,-36.0,M,,*7C'[0m
+[32mINFO - TS: 25611330 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25611863 Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 25612403 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 25612937 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 25613475 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 25614006 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25614545 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.19 knots (0.35 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331766666667, Lon=-80.536709, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25615237 Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25615774 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 25616319 Accel: X=-0.053g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.330dps Z=-0.875dps[0m
+[32mINFO - TS: 25616858 Accel: X=-0.050g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 25617396 Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.575dps Z=-0.700dps[0m
+[32mINFO - TS: 25617930 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 25618466 Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 25618996 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.19 knots (0.36 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670916666667, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25619561 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 25620101 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.595dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25620631 Accel: X=-0.051g Y=0.198g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 25621167 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 25621700 Accel: X=-0.050g Y=0.202g Z=0.989g Gyro: X=0.560dps Y=-1.575dps Z=-0.910dps[0m
+[32mINFO - TS: 25622238 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.365dps Z=-0.945dps[0m
+[32mINFO - TS: 25622767 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 25623305 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.11 knots (0.20 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670883333334, HDOP=2.05, SATS=8[0m
+[32mINFO - TS: 25623846 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.420dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 25624386 Accel: X=-0.054g Y=0.202g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25624924 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 25625458 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25625996 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.365dps Z=-0.840dps[0m
+[32mINFO - TS: 25626533 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.490dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 25627068 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 25627603 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 25628143 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
 [32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.12 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329366666666, Lon=-80.5368745, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8078685 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8079228 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8079768 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8080308 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8080848 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8081389 Accel: X=-0.051g Y=0.200g Z=0.989g Gyro: X=0.665dps Y=-1.540dps Z=-1.050dps[0m
-[32mINFO - TS: 8081928 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.02 knots (0.04 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329383333334, Lon=-80.53687433333333, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8082464 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 8083203 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.560dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8083735 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.770dps Y=-1.575dps Z=-0.980dps[0m
-[32mINFO - TS: 8084267 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.805dps[0m
-[32mINFO - TS: 8084817 Accel: X=-0.051g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.610dps Z=-0.945dps[0m
-[32mINFO - TS: 8085354 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.840dps[0m
-[32mINFO - TS: 8085892 Accel: X=-0.052g Y=0.201g Z=0.989g Gyro: X=0.525dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - TS: 8086426 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.805dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.19 knots (0.34 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329366666666, Lon=-80.536876, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8086972 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8087517 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.420dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8088057 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8088589 Accel: X=-0.054g Y=0.202g Z=0.988g Gyro: X=0.770dps Y=-1.540dps Z=-0.770dps[0m
-[32mINFO - TS: 8089120 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.595dps Y=-1.435dps Z=-0.770dps[0m
-[32mINFO - TS: 8089655 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.470dps Z=-0.735dps[0m
-[32mINFO - TS: 8090189 Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8090728 Accel: X=-0.052g Y=0.201g Z=0.989g Gyro: X=0.595dps Y=-1.575dps Z=-0.945dps[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: ,2,10,1.92,384.2,M,-36.0,M,,*73 for sentence: ',2,10,1.92,384.2,M,-36.0,M,,*73'[0m
-[32mINFO - TS: 8091269 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8091802 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.980dps[0m
-[32mINFO - TS: 8092339 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.525dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8092876 Accel: X=-0.051g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.770dps[0m
-[32mINFO - TS: 8093416 Accel: X=-0.051g Y=0.202g Z=0.989g Gyro: X=0.665dps Y=-1.470dps Z=-0.770dps[0m
-[32mINFO - TS: 8093952 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8094488 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.10 knots (0.18 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473293166666664, Lon=-80.5368765, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8095213 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.595dps Y=-1.400dps Z=-0.840dps[0m
-[32mINFO - TS: 8095750 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8096288 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.770dps[0m
-[32mINFO - TS: 8096823 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.630dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 8097356 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 8097893 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.645dps Z=-0.875dps[0m
-[32mINFO - TS: 8098428 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.945dps[0m
-[32mINFO - TS: 8098968 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.945dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.07 knots (0.14 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687733333334, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8099651 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 8100208 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 8100740 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.525dps Y=-1.610dps Z=-0.840dps[0m
-[32mINFO - TS: 8101272 Accel: X=-0.051g Y=0.201g Z=0.989g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8101807 Accel: X=-0.052g Y=0.203g Z=0.987g Gyro: X=0.840dps Y=-1.505dps Z=-0.980dps[0m
-[32mINFO - TS: 8102345 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8102876 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.04 knots (0.08 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687716666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8103562 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.470dps Z=-0.770dps[0m
-[32mINFO - TS: 8104100 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - TS: 8104634 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 8105172 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - TS: 8105706 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8106245 Accel: X=-0.053g Y=0.203g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8106776 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8107307 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.525dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8107846 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.24 knots (0.44 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473293166666664, Lon=-80.53687733333334, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8108387 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.805dps[0m
-[32mINFO - TS: 8108924 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8109458 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 8109998 Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.770dps Y=-1.435dps Z=-0.980dps[0m
-[32mINFO - TS: 8110529 Accel: X=-0.051g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.945dps[0m
-[32mINFO - TS: 8111062 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8111600 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.23 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473293, Lon=-80.53687766666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8112142 Accel: X=-0.050g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.770dps[0m
-[32mINFO - TS: 8112696 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.645dps Z=-0.840dps[0m
-[32mINFO - TS: 8113236 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.910dps[0m
-[32mINFO - TS: 8113776 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8114314 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.470dps Z=-0.805dps[0m
-[32mINFO - [ESP-NOW TX] Heartbeat sent (time=1366735us)[0m
-[32mINFO - TS: 8114870 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8115407 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.11 knots (0.21 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687783333334, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8116071 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.455dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8116624 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 8117160 Accel: X=-0.054g Y=0.199g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-1.050dps[0m
-[32mINFO - TS: 8117696 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8118232 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8118769 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8119303 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - TS: 8119835 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.01 knots (0.02 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473293, Lon=-80.53687766666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8120376 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 8120910 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8121444 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8121984 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.645dps Z=-0.840dps[0m
-[32mINFO - TS: 8122519 Accel: X=-0.050g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - TS: 8123051 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8123587 Accel: X=-0.053g Y=0.203g Z=0.987g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8124126 Accel: X=-0.051g Y=0.200g Z=0.985g Gyro: X=0.595dps Y=-1.470dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.02 knots (0.03 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687783333334, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8124665 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8125205 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 8125740 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.490dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8126275 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.610dps Z=-0.770dps[0m
-[32mINFO - TS: 8126813 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 8127353 Accel: X=-0.051g Y=0.200g Z=0.984g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 8127890 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.18 knots (0.33 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.4732925, Lon=-80.53687816666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8128580 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.945dps[0m
-[32mINFO - TS: 8129129 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.770dps Y=-1.505dps Z=-0.735dps[0m
-[32mINFO - TS: 8129660 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.805dps[0m
-[32mINFO - TS: 8130195 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8130734 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
-[32mINFO - TS: 8131271 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8131802 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
-[32mINFO - TS: 8132333 Accel: X=-0.052g Y=0.200g Z=0.984g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.09 knots (0.16 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473292666666666, Lon=-80.5368785, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8132876 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.805dps[0m
-[32mINFO - TS: 8133419 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8133955 Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.595dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 8134489 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 8135030 Accel: X=-0.050g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8135562 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 8136100 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8136635 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.610dps Z=-0.840dps[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: ,M,,*77 for sentence: ',M,,*77'[0m
-[32mINFO - TS: 8137177 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.840dps Y=-1.470dps Z=-0.805dps[0m
-[32mINFO - TS: 8137713 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 8138253 Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 8138788 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.525dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8139327 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8139863 Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8140398 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.10 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329233333333, Lon=-80.536879, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8141069 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.645dps Z=-0.945dps[0m
-[32mINFO - TS: 8141605 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8142143 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.665dps Y=-1.365dps Z=-0.805dps[0m
-[32mINFO - TS: 8142678 Accel: X=-0.053g Y=0.199g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 8143212 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8143744 Accel: X=-0.053g Y=0.199g Z=0.984g Gyro: X=0.700dps Y=-1.400dps Z=-0.840dps[0m
-[32mINFO - TS: 8144275 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.645dps Z=-0.875dps[0m
-[32mINFO - TS: 8144811 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.21 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329216666667, Lon=-80.53687916666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8145357 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 8145899 Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 8146434 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8146969 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8147507 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.680dps Z=-0.910dps[0m
-[32mINFO - TS: 8148044 Accel: X=-0.050g Y=0.199g Z=0.987g Gyro: X=0.560dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8148580 Accel: X=-0.050g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 8149116 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8149648 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.07 knots (0.13 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473292, Lon=-80.53687966666666, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8150190 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 8150729 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.455dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8151269 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 8151808 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.700dps Y=-1.435dps Z=-0.980dps[0m
-[32mINFO - TS: 8152341 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.400dps Z=-1.015dps[0m
-[32mINFO - TS: 8152870 Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.01 knots (0.02 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473291833333334, Lon=-80.53688016666666, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8153559 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8154104 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.420dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8154644 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 8155182 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.330dps Z=-0.910dps[0m
-[32mINFO - TS: 8155718 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.805dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 8156254 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.945dps[0m
-[32mINFO - [ESP-NOW TX] Heartbeat sent (time=2368199us)[0m
-[32mINFO - TS: 8156790 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.770dps Y=-1.435dps Z=-0.910dps[0m
-[32mINFO - TS: 8157323 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.10 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329166666667, Lon=-80.53688066666666, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8157869 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 8158410 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.715dps Z=-0.875dps[0m
-[32mINFO - TS: 8158947 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8159743 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8160027 Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.770dps Y=-1.365dps Z=-0.875dps[0m
-[32mINFO - TS: 8160565 Accel: X=-0.053g Y=0.199g Z=0.985g Gyro: X=0.700dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 8161097 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.455dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 8161629 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[31mERROR - UART Read Error: FifoOverflowed[0m
-[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: ,10,1.92,384.7,M,-36.0,M,,*7F for sentence: ',10,1.92,384.7,M,-36.0,M,,*7F'[0m
-[32mINFO - TS: 8162171 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8162712 Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.770dps Y=-1.505dps Z=-0.770dps[0m
-[32mINFO - TS: 8163247 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.645dps Z=-0.805dps[0m
-[32mINFO - TS: 8163786 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.400dps Z=-0.735dps[0m
-[32mINFO - TS: 8164326 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 8165116 Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8165391 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.10 knots (0.19 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473291, Lon=-80.536882, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8166074 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.770dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8166610 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8167146 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8167934 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.610dps Z=-0.840dps[0m
-[32mINFO - TS: 8168216 Accel: X=-0.051g Y=0.204g Z=0.985g Gyro: X=0.525dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8168750 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8169289 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 8169821 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.22 knots (0.40 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473290666666664, Lon=-80.5368825, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8170367 Accel: X=-0.052g Y=0.201g Z=0.989g Gyro: X=0.490dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 8170912 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 8171447 Accel: X=-0.052g Y=0.200g Z=0.984g Gyro: X=0.560dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8171979 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.525dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8172515 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.805dps Y=-1.365dps Z=-0.840dps[0m
-[32mINFO - TS: 8173050 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8173583 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.805dps[0m
-[32mINFO - TS: 8174119 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.770dps Y=-1.505dps Z=-0.770dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.29 knots (0.54 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688266666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8174659 Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.610dps Z=-0.910dps[0m
-[32mINFO - TS: 8175200 Accel: X=-0.053g Y=0.199g Z=0.983g Gyro: X=0.665dps Y=-1.365dps Z=-0.910dps[0m
-[32mINFO - TS: 8175732 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8176265 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8176806 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 8177340 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.680dps Z=-0.875dps[0m
-[32mINFO - TS: 8177880 Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.10 knots (0.18 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688233333334, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8178583 Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - TS: 8179118 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.805dps[0m
-[32mINFO - TS: 8179652 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.680dps Z=-0.945dps[0m
-[32mINFO - TS: 8180186 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-1.015dps[0m
-[32mINFO - TS: 8180720 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8181260 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8181792 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8182328 Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.665dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GPGGA FIX: Lat=43.473318, Lon=-80.53670866666667, HDOP=2.05, SATS=8[0m
+[32mINFO - TS: 25628686 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.575dps Z=-0.980dps[0m
+[32mINFO - TS: 25629220 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25629753 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 25630291 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 25630822 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 25631358 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
 [32mINFO - GNVTG VELOCITY: Speed=0.14 knots (0.27 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688266666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8182875 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8183426 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8183962 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8184498 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.525dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 8185037 Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8185575 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.435dps Z=-0.805dps[0m
-[32mINFO - TS: 8186112 Accel: X=-0.051g Y=0.203g Z=0.987g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8186652 Accel: X=-0.051g Y=0.203g Z=0.984g Gyro: X=0.630dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.27 knots (0.50 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688283333334, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8187201 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.770dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8187744 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
-[32mINFO - TS: 8188279 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.560dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8188818 Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.560dps Y=-1.365dps Z=-0.875dps[0m
-[32mINFO - TS: 8189358 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - TS: 8189898 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.980dps[0m
-[32mINFO - TS: 8190430 Accel: X=-0.051g Y=0.200g Z=0.985g Gyro: X=0.630dps Y=-1.400dps Z=-0.735dps[0m
-[32mINFO - TS: 8190962 Accel: X=-0.051g Y=0.199g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.875dps[0m
-[32mINFO - TS: 8191498 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GPGGA FIX: Lat=43.473318, Lon=-80.5367085, HDOP=2.05, SATS=8[0m
+[32mINFO - TS: 25632012 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 25632559 Accel: X=-0.052g Y=0.203g Z=0.986g Gyro: X=0.595dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 25633094 Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 25633627 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25634161 Accel: X=-0.054g Y=0.202g Z=0.988g Gyro: X=0.735dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 25634692 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.575dps Z=-0.910dps[0m
+[32mINFO - TS: 25635224 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.805dps Y=-1.400dps Z=-0.875dps[0m
+[32mINFO - TS: 25635761 Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.735dps Y=-1.365dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.13 knots (0.24 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473318166666665, Lon=-80.53670833333334, HDOP=2.05, SATS=8[0m
+[32mINFO - TS: 25636304 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 25636840 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-1.015dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=1367320us)[0m
+[32mINFO - TS: 25637381 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 25637916 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 25638452 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 25638985 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 25639524 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.575dps Z=-0.770dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.08 knots (0.14 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473318, Lon=-80.53670816666667, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25640057 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 25640778 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 25641318 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 25641850 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 25642381 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 25642916 Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 25643449 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 25643981 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.11 knots (0.20 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670833333334, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25644572 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 25645115 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 25645649 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.805dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 25646187 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.770dps Y=-1.505dps Z=-0.980dps[0m
+[32mINFO - TS: 25646724 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.525dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 25647254 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 25647785 Accel: X=-0.054g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.645dps Z=-0.840dps[0m
+[32mINFO - TS: 25648323 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.490dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.09 knots (0.16 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.5367085, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25648866 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 25649409 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 25649948 Accel: X=-0.053g Y=0.200g Z=0.989g Gyro: X=0.840dps Y=-1.435dps Z=-0.980dps[0m
+[32mINFO - TS: 25650486 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.840dps Y=-1.540dps Z=-0.700dps[0m
+[32mINFO - TS: 25651018 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 25651553 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.770dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 25652091 Accel: X=-0.051g Y=0.201g Z=0.989g Gyro: X=0.630dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
 [32mINFO - GNVTG VELOCITY: Speed=0.24 knots (0.44 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.536883, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8192045 Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.770dps Y=-1.470dps Z=-1.015dps[0m
-[32mINFO - TS: 8192598 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 8193134 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.805dps Y=-1.540dps Z=-1.015dps[0m
-[32mINFO - TS: 8193670 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.575dps Z=-0.945dps[0m
-[32mINFO - TS: 8194208 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
-[32mINFO - TS: 8194743 Accel: X=-0.053g Y=0.202g Z=0.985g Gyro: X=0.735dps Y=-1.645dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.17 knots (0.32 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473290666666664, Lon=-80.53688316666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8195328 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8195878 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8196418 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.805dps[0m
-[32mINFO - TS: 8196957 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.770dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8197491 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8198041 Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.525dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - [ESP-NOW TX] Heartbeat sent (time=3371356us)[0m
-[32mINFO - TS: 8198581 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8199120 Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.22 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329033333333, Lon=-80.53688366666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8199656 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.805dps[0m
-[32mINFO - TS: 8200192 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.595dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 8200730 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 8201268 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
-[32mINFO - TS: 8201808 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.455dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 8202345 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8202882 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670883333334, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25652807 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 25653348 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.910dps[0m
+[32mINFO - TS: 25653882 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 25654419 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 25654958 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 25655491 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 25656030 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.680dps Z=-0.770dps[0m
+[32mINFO - TS: 25656564 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.680dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.22 knots (0.41 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331833333333, Lon=-80.53670816666667, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25657158 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.735dps[0m
+[32mINFO - TS: 25657694 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 25658228 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 25658765 Accel: X=-0.054g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-1.015dps[0m
+[32mINFO - TS: 25659302 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 25659836 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25660367 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25660897 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.14 knots (0.25 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473318166666665, Lon=-80.53670833333334, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25661440 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25661982 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 25662521 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25663052 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.560dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 25663586 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.560dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25664117 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25664647 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.610dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:16 UTC[0m
 [32mINFO - GNVTG VELOCITY: Speed=0.15 knots (0.28 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329033333333, Lon=-80.53688366666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8203417 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - TS: 8204133 Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.595dps Y=-1.400dps Z=-0.875dps[0m
-[32mINFO - TS: 8204671 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8205207 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.435dps Z=-0.840dps[0m
-[32mINFO - TS: 8205742 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.770dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - TS: 8206277 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8206816 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.610dps Z=-0.945dps[0m
-[32mINFO - TS: 8207352 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.23 knots (0.42 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688383333333, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8207896 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.455dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8208453 Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.365dps Z=-0.770dps[0m
-[32mINFO - TS: 8208985 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8209517 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8210057 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
-[32mINFO - TS: 8210596 Accel: X=-0.051g Y=0.199g Z=0.985g Gyro: X=0.770dps Y=-1.505dps Z=-0.980dps[0m
-[32mINFO - TS: 8211136 Accel: X=-0.051g Y=0.203g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
-[32mINFO - TS: 8211675 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.15 knots (0.29 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688383333333, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8212219 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8212759 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.455dps Y=-1.330dps Z=-0.840dps[0m
-[32mINFO - TS: 8213300 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.490dps Y=-1.400dps Z=-0.840dps[0m
-[32mINFO - TS: 8213832 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.805dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8214370 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8214905 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8215439 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.805dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.23 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688416666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8216154 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8216696 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8217235 Accel: X=-0.054g Y=0.199g Z=0.985g Gyro: X=0.700dps Y=-1.470dps Z=-0.980dps[0m
-[32mINFO - TS: 8217770 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8218307 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.610dps Z=-0.980dps[0m
-[32mINFO - TS: 8218843 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.910dps[0m
-[32mINFO - TS: 8219375 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8219911 Accel: X=-0.052g Y=0.200g Z=0.984g Gyro: X=0.595dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.17 knots (0.32 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.47329033333333, Lon=-80.53688433333333, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8220457 Accel: X=-0.054g Y=0.199g Z=0.986g Gyro: X=0.770dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 8220991 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.840dps[0m
-[32mINFO - TS: 8221529 Accel: X=-0.052g Y=0.201g Z=0.984g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8222068 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.435dps Z=-0.945dps[0m
-[32mINFO - TS: 8222607 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.435dps Z=-0.980dps[0m
-[32mINFO - TS: 8223138 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8223675 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.805dps[0m
-[32mINFO - TS: 8224214 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.20 knots (0.36 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688416666667, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8224755 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
-[32mINFO - TS: 8225295 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.645dps Z=-0.840dps[0m
-[32mINFO - TS: 8225830 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.400dps Z=-0.875dps[0m
-[32mINFO - TS: 8226369 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
-[32mINFO - TS: 8226908 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - TS: 8227447 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.435dps Z=-0.910dps[0m
-[32mINFO - TS: 8227986 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.17 knots (0.32 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.473290666666664, Lon=-80.536884, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8228716 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.910dps[0m
-[32mINFO - TS: 8229267 Accel: X=-0.053g Y=0.199g Z=0.989g Gyro: X=0.665dps Y=-1.540dps Z=-0.980dps[0m
-[32mINFO - TS: 8229800 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 8230335 Accel: X=-0.051g Y=0.200g Z=0.985g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8230873 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.945dps[0m
-[32mINFO - TS: 8231408 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.505dps Z=-1.050dps[0m
-[32mINFO - TS: 8231938 Accel: X=-0.050g Y=0.200g Z=0.985g Gyro: X=0.630dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 8232476 Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.610dps Z=-0.840dps[0m
-[32mINFO - TS: 8233009 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.840dps[0m
-[32mINFO - GPS rmc time is: 2026-01-16 03:21:19 UTC[0m
-[32mINFO - GNVTG VELOCITY: Speed=0.18 knots (0.34 km/h); Heading: 0[0m
-[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.5368845, HDOP=1.92, SATS=10[0m
-[32mINFO - TS: 8233679 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.770dps Y=-1.435dps Z=-0.875dps[0m
-[32mINFO - TS: 8234222 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.875dps[0m
-[32mINFO - TS: 8234759 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.945dps[0m
-[32mINFO - TS: 8235293 Accel: X=-0.052g Y=0.203g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
-[32mINFO - TS: 8235831 Accel: X=
+[32mINFO - GPGGA FIX: Lat=43.47331783333333, Lon=-80.53670833333334, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25665381 Accel: X=-0.053g Y=0.199g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 25665936 Accel: X=-0.053g Y=0.201g Z=0.989g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 25666473 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 25667012 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 25667549 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 25668087 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.525dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25668622 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 25669157 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25669695 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.610dps Z=-0.770dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.08 knots (0.15 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331833333333, Lon=-80.53670783333334, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25670323 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.945dps[0m
+[32mINFO - TS: 25670862 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 25671399 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 25671934 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.735dps Y=-1.400dps Z=-0.945dps[0m
+[32mINFO - TS: 25672471 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 25673009 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.525dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.31 knots (0.58 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473318166666665, Lon=-80.5367085, HDOP=1.8, SATS=9[0m
+[32mINFO - TS: 25673719 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.455dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 25674275 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 25674811 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 25675344 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.700dps[0m
+[32mINFO - TS: 25675878 Accel: X=-0.053g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 25676414 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 25676949 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 25677486 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.770dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: N,08032.20250,W,2,09,1.80,386.3,M,-36.0,M,,*72 for sentence: 'N,08032.20250,W,2,09,1.80,386.3,M,-36.0,M,,*72'[0m
+[32mINFO - TS: 25678021 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.525dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 25678561 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=2369161us)[0m
+[32mINFO - TS: 25679103 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 25679633 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 25680165 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 25680697 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 25681230 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 25681760 Accel: X=-0.055g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.875dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: 36.0,M,,*76 for sentence: '36.0,M,,*76'[0m
+[32mINFO - TS: 25682301 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 25682841 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 25683379 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 25683917 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 25684456 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.770dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 25684994 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 25685532 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:28:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.23 knots (0.43 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47331883333333, Lon=-80.536707, HDOP=1.8, SATS=10[0m
+[32mINFO - TS: 25686247 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-1.015dps[0m
+[32mINFO - TS: 25686790 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.610dps Z=-0.770dps[0m
+[32mINFO - TS: 25687329 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 25687867 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.575dps Z=-0.735dps[0m
+[32mINFO - TS: 25688406 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.840dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 25688941 Accel: X=-0.051g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 25689472 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.770dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 25690008 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.910dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: 08032.20238,W,2,10,1.80,386.0,M,-36.0,M,,*7C for sentence: '08032.20238,W,2,10,1.80,386.0,M,-36.0,M,,*7C'[0m
+[32mINFO - TS: 25690545 Accel: X=-0.053g Y=0.203g Z=0.987g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 25691085 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.980dps[0m

--- a/sw/sensor_board/sensor_board_rev1_test/hirate_log.txt
+++ b/sw/sensor_board/sensor_board_rev1_test/hirate_log.txt
@@ -1,0 +1,480 @@
+Chip type:         esp32c6 (revision v0.2)
+Crystal frequency: 40 MHz
+Flash size:        8MB
+Features:          WiFi 6, BT 5
+MAC address:       58:8c:81:40:be:0c
+App/part. size:    866,992/8,323,072 bytes, 10.42%
+Commands:
+    CTRL+R    Reset chip
+    CTRL+C    Exit
+
+ESP-ROM:esp32c6-20220919
+Build:Sep 19 2022
+rst:0x15 (USB_UART_HPSYS),boot:0x3f (SPI_FAST_FLASH_BOOT)
+Saved PC:0x40800822
+SPIWP:0xee
+mode:DIO, clock div:2
+load:0x40875730,len:0x175c
+load:0x4086b910,len:0xec8
+load:0x4086e610,len:0x31c4
+entry 0x4086b91a
+I (23) boot: ESP-IDF v5.5.1-838-gd66ebb86d2e 2nd stage bootloader
+I (23) boot: compile time Nov 27 2025 09:46:10
+I (24) boot: chip revision: v0.2
+I (24) boot: efuse block revision: v0.3
+I (28) boot.esp32c6: SPI Speed      : 80MHz
+I (32) boot.esp32c6: SPI Mode       : DIO
+I (36) boot.esp32c6: SPI Flash Size : 8MB
+I (39) boot: Enabling RNG early entropy source...
+I (44) boot: Partition Table:
+I (46) boot: ## Label            Usage          Type ST Offset   Length
+I (53) boot:  0 nvs              WiFi data        01 02 00009000 00006000
+I (59) boot:  1 phy_init         RF data          01 01 0000f000 00001000
+I (66) boot:  2 factory          factory app      00 00 00010000 007f0000
+I (72) boot: End of partition table
+I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=2e8b4h (190644) map
+I (119) esp_image: segment 1: paddr=0003e8dc vaddr=40800000 size=00014h (    20) load
+I (120) esp_image: segment 2: paddr=0003e8f8 vaddr=4202e8f8 size=92a6ch (600684) map
+I (238) esp_image: segment 3: paddr=000d136c vaddr=40800014 size=0e628h ( 58920) load
+I (252) esp_image: segment 4: paddr=000df99c vaddr=4080e640 size=03efch ( 16124) load
+I (256) esp_image: segment 5: paddr=000e38a0 vaddr=40812540 size=001e0h (   480) load
+I (261) boot: Loaded app from partition at offset 0x10000
+I (261) boot: Disabling RNG early entropy source...
+[32mINFO - Configuration complete - running app?[0m
+[32mINFO - baudrate for gps2_uart_set[0m
+[32mINFO - WiFi initialized successfully[0m
+[32mINFO - app is starting execution now[0m
+[32mINFO - all periphs taken[0m
+[32mINFO - AirComm transceiver initialized[0m
+[32mINFO - ESP-NOW mode: Sender (transmit sensor data)[0m
+[32mINFO - [ESP-NOW] Sender task started[0m
+[32mINFO - Starting GPS configuration using $PUBX,40 commands...[0m
+[32mINFO - GPS Config: Sent command to disable GSA ($PUBX,40,GSA,0,0,0,0,0,0*4E)[0m
+[32mINFO - GPS Config: Sent command to disable GSV ($PUBX,40,GSV,0,0,0,0,0,0*59)[0m
+[32mINFO - GPS Config: Sent command to disable GLL ($PUBX,40,GLL,0,0,0,0,0,0*5C)[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[32mINFO - IMU TASK BEING SPAWNED[0m
+[32mINFO - In imu task![0m
+[32mINFO - Attempting to read WHOAMI at reg: 0x0F[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=363609us)[0m
+[32mINFO - WhoAmI value is 0x6B[0m
+[32mINFO - Timestamp enabled[0m
+[32mINFO - TS: 8073196 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8073735 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.08 knots (0.14 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329366666666, Lon=-80.53687566666666, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8074376 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8074922 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8075460 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8076000 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.700dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8076537 Accel: X=-0.053g Y=0.201g Z=0.989g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8077074 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 8077604 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8078142 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.12 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329366666666, Lon=-80.5368745, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8078685 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8079228 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8079768 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8080308 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8080848 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8081389 Accel: X=-0.051g Y=0.200g Z=0.989g Gyro: X=0.665dps Y=-1.540dps Z=-1.050dps[0m
+[32mINFO - TS: 8081928 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.02 knots (0.04 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329383333334, Lon=-80.53687433333333, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8082464 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 8083203 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.560dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8083735 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.770dps Y=-1.575dps Z=-0.980dps[0m
+[32mINFO - TS: 8084267 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 8084817 Accel: X=-0.051g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.610dps Z=-0.945dps[0m
+[32mINFO - TS: 8085354 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.665dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 8085892 Accel: X=-0.052g Y=0.201g Z=0.989g Gyro: X=0.525dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 8086426 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.805dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.19 knots (0.34 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329366666666, Lon=-80.536876, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8086972 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8087517 Accel: X=-0.051g Y=0.199g Z=0.987g Gyro: X=0.420dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8088057 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8088589 Accel: X=-0.054g Y=0.202g Z=0.988g Gyro: X=0.770dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 8089120 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.595dps Y=-1.435dps Z=-0.770dps[0m
+[32mINFO - TS: 8089655 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.470dps Z=-0.735dps[0m
+[32mINFO - TS: 8090189 Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8090728 Accel: X=-0.052g Y=0.201g Z=0.989g Gyro: X=0.595dps Y=-1.575dps Z=-0.945dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: ,2,10,1.92,384.2,M,-36.0,M,,*73 for sentence: ',2,10,1.92,384.2,M,-36.0,M,,*73'[0m
+[32mINFO - TS: 8091269 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8091802 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.980dps[0m
+[32mINFO - TS: 8092339 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.525dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8092876 Accel: X=-0.051g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 8093416 Accel: X=-0.051g Y=0.202g Z=0.989g Gyro: X=0.665dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 8093952 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8094488 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.10 knots (0.18 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473293166666664, Lon=-80.5368765, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8095213 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.595dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 8095750 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8096288 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.770dps[0m
+[32mINFO - TS: 8096823 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.630dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 8097356 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 8097893 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.645dps Z=-0.875dps[0m
+[32mINFO - TS: 8098428 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 8098968 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.945dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.07 knots (0.14 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687733333334, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8099651 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 8100208 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 8100740 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.525dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 8101272 Accel: X=-0.051g Y=0.201g Z=0.989g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8101807 Accel: X=-0.052g Y=0.203g Z=0.987g Gyro: X=0.840dps Y=-1.505dps Z=-0.980dps[0m
+[32mINFO - TS: 8102345 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8102876 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:15 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.04 knots (0.08 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687716666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8103562 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.470dps Z=-0.770dps[0m
+[32mINFO - TS: 8104100 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 8104634 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 8105172 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 8105706 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8106245 Accel: X=-0.053g Y=0.203g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8106776 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8107307 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.525dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8107846 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.24 knots (0.44 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473293166666664, Lon=-80.53687733333334, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8108387 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 8108924 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8109458 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 8109998 Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.770dps Y=-1.435dps Z=-0.980dps[0m
+[32mINFO - TS: 8110529 Accel: X=-0.051g Y=0.202g Z=0.988g Gyro: X=0.700dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 8111062 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8111600 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.23 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473293, Lon=-80.53687766666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8112142 Accel: X=-0.050g Y=0.199g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.770dps[0m
+[32mINFO - TS: 8112696 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.645dps Z=-0.840dps[0m
+[32mINFO - TS: 8113236 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 8113776 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8114314 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=1366735us)[0m
+[32mINFO - TS: 8114870 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8115407 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.11 knots (0.21 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687783333334, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8116071 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.455dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8116624 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 8117160 Accel: X=-0.054g Y=0.199g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-1.050dps[0m
+[32mINFO - TS: 8117696 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8118232 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8118769 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8119303 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 8119835 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.01 knots (0.02 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473293, Lon=-80.53687766666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8120376 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 8120910 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8121444 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8121984 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.645dps Z=-0.840dps[0m
+[32mINFO - TS: 8122519 Accel: X=-0.050g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 8123051 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8123587 Accel: X=-0.053g Y=0.203g Z=0.987g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8124126 Accel: X=-0.051g Y=0.200g Z=0.985g Gyro: X=0.595dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.02 knots (0.03 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329283333333, Lon=-80.53687783333334, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8124665 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8125205 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 8125740 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.490dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8126275 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.610dps Z=-0.770dps[0m
+[32mINFO - TS: 8126813 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 8127353 Accel: X=-0.051g Y=0.200g Z=0.984g Gyro: X=0.665dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 8127890 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.18 knots (0.33 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.4732925, Lon=-80.53687816666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8128580 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.945dps[0m
+[32mINFO - TS: 8129129 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.770dps Y=-1.505dps Z=-0.735dps[0m
+[32mINFO - TS: 8129660 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.805dps[0m
+[32mINFO - TS: 8130195 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8130734 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 8131271 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8131802 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 8132333 Accel: X=-0.052g Y=0.200g Z=0.984g Gyro: X=0.700dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.09 knots (0.16 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473292666666666, Lon=-80.5368785, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8132876 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.400dps Z=-0.805dps[0m
+[32mINFO - TS: 8133419 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8133955 Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.595dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 8134489 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 8135030 Accel: X=-0.050g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8135562 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 8136100 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8136635 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.610dps Z=-0.840dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: ,M,,*77 for sentence: ',M,,*77'[0m
+[32mINFO - TS: 8137177 Accel: X=-0.053g Y=0.202g Z=0.986g Gyro: X=0.840dps Y=-1.470dps Z=-0.805dps[0m
+[32mINFO - TS: 8137713 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 8138253 Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 8138788 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.525dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8139327 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8139863 Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.665dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8140398 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.10 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329233333333, Lon=-80.536879, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8141069 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.645dps Z=-0.945dps[0m
+[32mINFO - TS: 8141605 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8142143 Accel: X=-0.052g Y=0.200g Z=0.989g Gyro: X=0.665dps Y=-1.365dps Z=-0.805dps[0m
+[32mINFO - TS: 8142678 Accel: X=-0.053g Y=0.199g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 8143212 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8143744 Accel: X=-0.053g Y=0.199g Z=0.984g Gyro: X=0.700dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 8144275 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.645dps Z=-0.875dps[0m
+[32mINFO - TS: 8144811 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:16 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.21 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329216666667, Lon=-80.53687916666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8145357 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 8145899 Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 8146434 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8146969 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8147507 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.680dps Z=-0.910dps[0m
+[32mINFO - TS: 8148044 Accel: X=-0.050g Y=0.199g Z=0.987g Gyro: X=0.560dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8148580 Accel: X=-0.050g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 8149116 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8149648 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.07 knots (0.13 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473292, Lon=-80.53687966666666, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8150190 Accel: X=-0.053g Y=0.200g Z=0.986g Gyro: X=0.735dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 8150729 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.455dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8151269 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 8151808 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.700dps Y=-1.435dps Z=-0.980dps[0m
+[32mINFO - TS: 8152341 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.400dps Z=-1.015dps[0m
+[32mINFO - TS: 8152870 Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.01 knots (0.02 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473291833333334, Lon=-80.53688016666666, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8153559 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8154104 Accel: X=-0.053g Y=0.202g Z=0.988g Gyro: X=0.420dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8154644 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 8155182 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.330dps Z=-0.910dps[0m
+[32mINFO - TS: 8155718 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.805dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 8156254 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=2368199us)[0m
+[32mINFO - TS: 8156790 Accel: X=-0.052g Y=0.200g Z=0.985g Gyro: X=0.770dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 8157323 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.06 knots (0.10 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329166666667, Lon=-80.53688066666666, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8157869 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 8158410 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.715dps Z=-0.875dps[0m
+[32mINFO - TS: 8158947 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8159743 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8160027 Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.770dps Y=-1.365dps Z=-0.875dps[0m
+[32mINFO - TS: 8160565 Accel: X=-0.053g Y=0.199g Z=0.985g Gyro: X=0.700dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 8161097 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.455dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 8161629 Accel: X=-0.053g Y=0.201g Z=0.988g Gyro: X=0.595dps Y=-1.540dps Z=-0.875dps[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[31mERROR - UART Read Error: FifoOverflowed[0m
+[33mWARN - NMEA Parse Error: Invalid NMEA sentence: Invalid NMEA sentence: ,10,1.92,384.7,M,-36.0,M,,*7F for sentence: ',10,1.92,384.7,M,-36.0,M,,*7F'[0m
+[32mINFO - TS: 8162171 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8162712 Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.770dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - TS: 8163247 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.645dps Z=-0.805dps[0m
+[32mINFO - TS: 8163786 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.400dps Z=-0.735dps[0m
+[32mINFO - TS: 8164326 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 8165116 Accel: X=-0.054g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8165391 Accel: X=-0.052g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.10 knots (0.19 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473291, Lon=-80.536882, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8166074 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.770dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8166610 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8167146 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8167934 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.735dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 8168216 Accel: X=-0.051g Y=0.204g Z=0.985g Gyro: X=0.525dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8168750 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8169289 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 8169821 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.22 knots (0.40 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473290666666664, Lon=-80.5368825, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8170367 Accel: X=-0.052g Y=0.201g Z=0.989g Gyro: X=0.490dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 8170912 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.735dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 8171447 Accel: X=-0.052g Y=0.200g Z=0.984g Gyro: X=0.560dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8171979 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.525dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8172515 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.805dps Y=-1.365dps Z=-0.840dps[0m
+[32mINFO - TS: 8173050 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.595dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8173583 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.805dps[0m
+[32mINFO - TS: 8174119 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.770dps Y=-1.505dps Z=-0.770dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.29 knots (0.54 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688266666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8174659 Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.610dps Z=-0.910dps[0m
+[32mINFO - TS: 8175200 Accel: X=-0.053g Y=0.199g Z=0.983g Gyro: X=0.665dps Y=-1.365dps Z=-0.910dps[0m
+[32mINFO - TS: 8175732 Accel: X=-0.054g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8176265 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8176806 Accel: X=-0.051g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 8177340 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.680dps Z=-0.875dps[0m
+[32mINFO - TS: 8177880 Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.10 knots (0.18 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688233333334, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8178583 Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.630dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 8179118 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - TS: 8179652 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.680dps Z=-0.945dps[0m
+[32mINFO - TS: 8180186 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-1.015dps[0m
+[32mINFO - TS: 8180720 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8181260 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.665dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8181792 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8182328 Accel: X=-0.052g Y=0.202g Z=0.985g Gyro: X=0.665dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.14 knots (0.27 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688266666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8182875 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8183426 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.525dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8183962 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8184498 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.525dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 8185037 Accel: X=-0.053g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8185575 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.630dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 8186112 Accel: X=-0.051g Y=0.203g Z=0.987g Gyro: X=0.630dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8186652 Accel: X=-0.051g Y=0.203g Z=0.984g Gyro: X=0.630dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:17 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.27 knots (0.50 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.53688283333334, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8187201 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.770dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8187744 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 8188279 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.560dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8188818 Accel: X=-0.053g Y=0.200g Z=0.985g Gyro: X=0.560dps Y=-1.365dps Z=-0.875dps[0m
+[32mINFO - TS: 8189358 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.735dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - TS: 8189898 Accel: X=-0.053g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.470dps Z=-0.980dps[0m
+[32mINFO - TS: 8190430 Accel: X=-0.051g Y=0.200g Z=0.985g Gyro: X=0.630dps Y=-1.400dps Z=-0.735dps[0m
+[32mINFO - TS: 8190962 Accel: X=-0.051g Y=0.199g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.875dps[0m
+[32mINFO - TS: 8191498 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.735dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.24 knots (0.44 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329083333333, Lon=-80.536883, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8192045 Accel: X=-0.052g Y=0.199g Z=0.985g Gyro: X=0.770dps Y=-1.470dps Z=-1.015dps[0m
+[32mINFO - TS: 8192598 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 8193134 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.805dps Y=-1.540dps Z=-1.015dps[0m
+[32mINFO - TS: 8193670 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.575dps Z=-0.945dps[0m
+[32mINFO - TS: 8194208 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.595dps Y=-1.470dps Z=-0.945dps[0m
+[32mINFO - TS: 8194743 Accel: X=-0.053g Y=0.202g Z=0.985g Gyro: X=0.735dps Y=-1.645dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.17 knots (0.32 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473290666666664, Lon=-80.53688316666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8195328 Accel: X=-0.052g Y=0.202g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8195878 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.770dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8196418 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.805dps[0m
+[32mINFO - TS: 8196957 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.770dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8197491 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8198041 Accel: X=-0.053g Y=0.200g Z=0.988g Gyro: X=0.525dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - [ESP-NOW TX] Heartbeat sent (time=3371356us)[0m
+[32mINFO - TS: 8198581 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8199120 Accel: X=-0.052g Y=0.199g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.22 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329033333333, Lon=-80.53688366666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8199656 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.700dps Y=-1.575dps Z=-0.805dps[0m
+[32mINFO - TS: 8200192 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.595dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 8200730 Accel: X=-0.051g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 8201268 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.665dps Y=-1.400dps Z=-0.910dps[0m
+[32mINFO - TS: 8201808 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.455dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 8202345 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.595dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8202882 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.700dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.15 knots (0.28 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329033333333, Lon=-80.53688366666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8203417 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - TS: 8204133 Accel: X=-0.052g Y=0.199g Z=0.988g Gyro: X=0.595dps Y=-1.400dps Z=-0.875dps[0m
+[32mINFO - TS: 8204671 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.630dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8205207 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.435dps Z=-0.840dps[0m
+[32mINFO - TS: 8205742 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.770dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - TS: 8206277 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.595dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8206816 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.630dps Y=-1.610dps Z=-0.945dps[0m
+[32mINFO - TS: 8207352 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.735dps Y=-1.575dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.23 knots (0.42 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688383333333, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8207896 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.455dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8208453 Accel: X=-0.054g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.365dps Z=-0.770dps[0m
+[32mINFO - TS: 8208985 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8209517 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8210057 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.575dps Z=-0.840dps[0m
+[32mINFO - TS: 8210596 Accel: X=-0.051g Y=0.199g Z=0.985g Gyro: X=0.770dps Y=-1.505dps Z=-0.980dps[0m
+[32mINFO - TS: 8211136 Accel: X=-0.051g Y=0.203g Z=0.987g Gyro: X=0.595dps Y=-1.540dps Z=-0.840dps[0m
+[32mINFO - TS: 8211675 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.630dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.15 knots (0.29 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688383333333, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8212219 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8212759 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.455dps Y=-1.330dps Z=-0.840dps[0m
+[32mINFO - TS: 8213300 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.490dps Y=-1.400dps Z=-0.840dps[0m
+[32mINFO - TS: 8213832 Accel: X=-0.052g Y=0.201g Z=0.987g Gyro: X=0.805dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8214370 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8214905 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8215439 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.735dps Y=-1.540dps Z=-0.805dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.12 knots (0.23 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688416666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8216154 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.805dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8216696 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8217235 Accel: X=-0.054g Y=0.199g Z=0.985g Gyro: X=0.700dps Y=-1.470dps Z=-0.980dps[0m
+[32mINFO - TS: 8217770 Accel: X=-0.051g Y=0.202g Z=0.985g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8218307 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.610dps Z=-0.980dps[0m
+[32mINFO - TS: 8218843 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.560dps Y=-1.540dps Z=-0.910dps[0m
+[32mINFO - TS: 8219375 Accel: X=-0.052g Y=0.201g Z=0.985g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8219911 Accel: X=-0.052g Y=0.200g Z=0.984g Gyro: X=0.595dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.17 knots (0.32 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.47329033333333, Lon=-80.53688433333333, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8220457 Accel: X=-0.054g Y=0.199g Z=0.986g Gyro: X=0.770dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 8220991 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.630dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 8221529 Accel: X=-0.052g Y=0.201g Z=0.984g Gyro: X=0.630dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8222068 Accel: X=-0.052g Y=0.200g Z=0.986g Gyro: X=0.595dps Y=-1.435dps Z=-0.945dps[0m
+[32mINFO - TS: 8222607 Accel: X=-0.052g Y=0.199g Z=0.987g Gyro: X=0.595dps Y=-1.435dps Z=-0.980dps[0m
+[32mINFO - TS: 8223138 Accel: X=-0.053g Y=0.201g Z=0.987g Gyro: X=0.560dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8223675 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.435dps Z=-0.805dps[0m
+[32mINFO - TS: 8224214 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.20 knots (0.36 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.53688416666667, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8224755 Accel: X=-0.052g Y=0.201g Z=0.988g Gyro: X=0.665dps Y=-1.505dps Z=-0.910dps[0m
+[32mINFO - TS: 8225295 Accel: X=-0.052g Y=0.200g Z=0.987g Gyro: X=0.630dps Y=-1.645dps Z=-0.840dps[0m
+[32mINFO - TS: 8225830 Accel: X=-0.053g Y=0.200g Z=0.987g Gyro: X=0.700dps Y=-1.400dps Z=-0.875dps[0m
+[32mINFO - TS: 8226369 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.735dps Y=-1.505dps Z=-0.840dps[0m
+[32mINFO - TS: 8226908 Accel: X=-0.053g Y=0.201g Z=0.986g Gyro: X=0.560dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 8227447 Accel: X=-0.052g Y=0.202g Z=0.987g Gyro: X=0.595dps Y=-1.435dps Z=-0.910dps[0m
+[32mINFO - TS: 8227986 Accel: X=-0.052g Y=0.201g Z=0.986g Gyro: X=0.665dps Y=-1.540dps Z=-0.875dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:18 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.17 knots (0.32 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.473290666666664, Lon=-80.536884, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8228716 Accel: X=-0.051g Y=0.202g Z=0.986g Gyro: X=0.595dps Y=-1.470dps Z=-0.910dps[0m
+[32mINFO - TS: 8229267 Accel: X=-0.053g Y=0.199g Z=0.989g Gyro: X=0.665dps Y=-1.540dps Z=-0.980dps[0m
+[32mINFO - TS: 8229800 Accel: X=-0.051g Y=0.201g Z=0.987g Gyro: X=0.525dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 8230335 Accel: X=-0.051g Y=0.200g Z=0.985g Gyro: X=0.735dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8230873 Accel: X=-0.051g Y=0.200g Z=0.988g Gyro: X=0.665dps Y=-1.540dps Z=-0.945dps[0m
+[32mINFO - TS: 8231408 Accel: X=-0.051g Y=0.201g Z=0.985g Gyro: X=0.700dps Y=-1.505dps Z=-1.050dps[0m
+[32mINFO - TS: 8231938 Accel: X=-0.050g Y=0.200g Z=0.985g Gyro: X=0.630dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 8232476 Accel: X=-0.054g Y=0.200g Z=0.988g Gyro: X=0.560dps Y=-1.610dps Z=-0.840dps[0m
+[32mINFO - TS: 8233009 Accel: X=-0.052g Y=0.202g Z=0.986g Gyro: X=0.700dps Y=-1.470dps Z=-0.840dps[0m
+[32mINFO - GPS rmc time is: 2026-01-16 03:21:19 UTC[0m
+[32mINFO - GNVTG VELOCITY: Speed=0.18 knots (0.34 km/h); Heading: 0[0m
+[32mINFO - GPGGA FIX: Lat=43.4732905, Lon=-80.5368845, HDOP=1.92, SATS=10[0m
+[32mINFO - TS: 8233679 Accel: X=-0.051g Y=0.202g Z=0.987g Gyro: X=0.770dps Y=-1.435dps Z=-0.875dps[0m
+[32mINFO - TS: 8234222 Accel: X=-0.051g Y=0.201g Z=0.986g Gyro: X=0.700dps Y=-1.505dps Z=-0.875dps[0m
+[32mINFO - TS: 8234759 Accel: X=-0.051g Y=0.200g Z=0.986g Gyro: X=0.630dps Y=-1.505dps Z=-0.945dps[0m
+[32mINFO - TS: 8235293 Accel: X=-0.052g Y=0.203g Z=0.987g Gyro: X=0.700dps Y=-1.470dps Z=-0.875dps[0m
+[32mINFO - TS: 8235831 Accel: X=

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -48,6 +48,9 @@ static SENSOR_CHANNEL: Channel<CriticalSectionRawMutex, SensorPayload, SENSOR_CH
 pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mut board: B) {
     info!("app is starting execution now");
 
+    // Initialize global program start time used for unified logging timestamps
+    crate::timebase::set_program_start();
+
     #[cfg(feature = "hmi")]
     let user_led = board.take_user_led();
     #[cfg(feature = "hmi")]

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -104,10 +104,6 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
     send_nmea_command(&mut gps2_uart, GSV_PAYLOAD, "GSV").await;
     send_nmea_command(&mut gps2_uart, GLL_PAYLOAD, "GLL").await;
 
-    // TODO: Configure GPS for 10hz updates & 115200 baud
-    // ONLY DO THIS WHEN THE NEW GPS COMES IN, since we will have to set baud rate at configuration
-    // time, meaning we must set the baud for all the gps's, then change the code, then use the GPS
-
     // TODO: hide this behind cargo configuration flag
     // This sets baud to 460800
     // default for M8 is 9600, default for F10 is 38400. Reset to default, set high baud, then set

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -202,8 +202,10 @@ where
                 match parser.parse_sentence(sentence) {
                     Ok(parsed_data) => match parsed_data {
                         nmea_parser::ParsedMessage::Gga(gga) => {
+                            let elapsed_s = crate::timebase::elapsed_seconds();
                             info!(
-                                "GPGGA FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
+                                "t={:.3}s GPGGA FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
+                                elapsed_s,
                                 gga.latitude.unwrap_or(0.0),
                                 gga.longitude.unwrap_or(0.0),
                                 gga.hdop.unwrap_or(0.0),
@@ -234,7 +236,8 @@ where
                         }
                         nmea_parser::ParsedMessage::Rmc(rmc) => {
                             if let Some(time) = rmc.timestamp {
-                                info!("GPS rmc time is: {}", time);
+                                let elapsed_s = crate::timebase::elapsed_seconds();
+                            info!("t={:.3}s GPS rmc time is: {}", elapsed_s, time);
 
                                 // Update cached time from RMC
                                 last_time = Some(GpsTime {
@@ -266,9 +269,10 @@ where
                             let speed_knots = vtg.sog_knots.unwrap_or(0.0);
                             let speed_kph = vtg.sog_kph.unwrap_or(0.0);
                             let course = vtg.cog_true.unwrap_or(0.0);
+                            let elapsed_s = crate::timebase::elapsed_seconds();
                             info!(
-                                "GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
-                                speed_knots, speed_kph, course
+                                "t={:.3}s GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
+                                elapsed_s, speed_knots, speed_kph, course
                             );
 
                             // Update cached values from VTG

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -1,7 +1,9 @@
 use core::fmt::Write;
 use esp_hal::Async;
 use esp_hal::uart::Uart;
-use heapless::{String, Vec};
+use heapless::String;
+#[cfg(feature = "set_gps_10hz")]
+use heapless::Vec;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
@@ -46,6 +48,7 @@ async fn send_nmea_command(uart: &mut Uart<'static, Async>, payload: &str, name:
     }
 }
 
+#[cfg(feature = "set_gps_10hz")]
 async fn send_ubx_packet(
     uart: &mut Uart<'static, Async>,
     class: u8,
@@ -104,32 +107,35 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
     send_nmea_command(&mut gps2_uart, GSV_PAYLOAD, "GSV").await;
     send_nmea_command(&mut gps2_uart, GLL_PAYLOAD, "GLL").await;
 
-    // TODO: hide this behind cargo configuration flag
-    // This sets baud to 460800
-    // default for M8 is 9600, default for F10 is 38400. Reset to default, set high baud, then set
-    // high baud. Theoretically we can reconfigure the uart on the fly by dropping and re-creating
-    // but that seems really difficult and I don't want to do that
-    // send_nmea_command(&mut gps2_uart, "PUBX,41,1,3,3,460800,0", "SET BAUD 460800").await;
+    #[cfg(feature = "set_gps_high_baud")]
+    {
+        // This sets baud to 460800
+        // default for M8 is 9600, default for F10 is 38400. Reset to default, set high baud, then set
+        // high baud. Theoretically we can reconfigure the uart on the fly by dropping and re-creating
+        // but that seems really difficult and I don't want to do that
+        send_nmea_command(&mut gps2_uart, "PUBX,41,1,3,3,460800,0", "SET BAUD 460800").await;
+    }
 
-    // TODO: hide this behind cargo configuration flag
-    // This *should* set 10hz updates but I need to implement send_ubx_packet
-    // Correct 10-byte payload for VALSET
-    // const UBX_CFG_VALSET_10HZ_PAYLOAD: [u8; 10] = [
-    //     0x00, // Version 0
-    //     0x07, // Layer: 7 = RAM + Flash + BBR (Persistent)
-    //     0x00, 0x00, // Reserved
-    //     0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS
-    //     0x64, 0x00, // Value: 100ms (Little Endian U2)
-    // ];
-    // UNCOMMENT BELOW IF CONFIGURING A NEW GPS (saved to ROM)
-    // send_ubx_packet(
-    //     &mut gps2_uart,
-    //     0x06, // class: CFG
-    //     0x8A, // id: valset
-    //     &UBX_CFG_VALSET_10HZ_PAYLOAD,
-    //     "CFG-RATE-MEAS 10Hz", // update this if 25
-    // )
-    // .await;
+    #[cfg(feature = "set_gps_10hz")]
+    {
+        // This *should* set 10hz updates but I need to implement send_ubx_packet
+        const UBX_CFG_VALSET_10HZ_PAYLOAD: [u8; 10] = [
+            0x00, // Version 0
+            0x07, // Layer: 7 = RAM + Flash + BBR (Persistent)
+            0x00, 0x00, // Reserved
+            0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS
+            0x64, 0x00, // Value: 100ms (Little Endian U2)
+        ];
+        // UNCOMMENT BELOW IF CONFIGURING A NEW GPS (saved to ROM)
+        send_ubx_packet(
+            &mut gps2_uart,
+            0x06, // class: CFG
+            0x8A, // id: valset
+            &UBX_CFG_VALSET_10HZ_PAYLOAD,
+            "CFG-RATE-MEAS 10Hz",
+        )
+        .await;
+    }
 
     gps2_uart
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -9,7 +9,7 @@ use crate::types::{GpsData, GpsTime};
 
 const NMEA_0183_MAX_LENGTH: usize = 83;
 const MAX_SENTENCE_LENGTH: usize = NMEA_0183_MAX_LENGTH + 2; // give ourselves buffer for newlines
-const NUM_NMEA_SENTENCES: usize = 3; // RMC, VTG, GGA
+const NUM_NMEA_SENTENCES: usize = 5; // RMC, VTG, GGA
 const CHUNK_BUFF_SIZE: usize = MAX_SENTENCE_LENGTH * (NUM_NMEA_SENTENCES + 1); // buffer
 const UNPROCESSED_BUFF_SIZE: usize = CHUNK_BUFF_SIZE * 2; // hold 2 chunks
 
@@ -108,21 +108,23 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
     // ONLY DO THIS WHEN THE NEW GPS COMES IN, since we will have to set baud rate at configuration
     // time, meaning we must set the baud for all the gps's, then change the code, then use the GPS
 
+    // TODO: hide this behind cargo configuration flag
     // This sets baud to 460800
     // default for M8 is 9600, default for F10 is 38400. Reset to default, set high baud, then set
     // high baud. Theoretically we can reconfigure the uart on the fly by dropping and re-creating
     // but that seems really difficult and I don't want to do that
     // send_nmea_command(&mut gps2_uart, "PUBX,41,1,3,3,460800,0", "SET BAUD 460800").await;
 
+    // TODO: hide this behind cargo configuration flag
     // This *should* set 10hz updates but I need to implement send_ubx_packet
     // Correct 10-byte payload for VALSET
-    const UBX_CFG_VALSET_10HZ_PAYLOAD: [u8; 10] = [
-        0x00, // Version 0
-        0x07, // Layer: 7 = RAM + Flash + BBR (Persistent)
-        0x00, 0x00, // Reserved
-        0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS
-        0x64, 0x00, // Value: 100ms (Little Endian U2)
-    ];
+    // const UBX_CFG_VALSET_10HZ_PAYLOAD: [u8; 10] = [
+    //     0x00, // Version 0
+    //     0x07, // Layer: 7 = RAM + Flash + BBR (Persistent)
+    //     0x00, 0x00, // Reserved
+    //     0x01, 0x00, 0x21, 0x30, // Key ID: CFG-RATE-MEAS
+    //     0x64, 0x00, // Value: 100ms (Little Endian U2)
+    // ];
     // UNCOMMENT BELOW IF CONFIGURING A NEW GPS (saved to ROM)
     // send_ubx_packet(
     //     &mut gps2_uart,

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
@@ -7,7 +7,10 @@ use embassy_time::{Duration, Timer};
 
 use crate::SharedSpiDevice;
 #[allow(unused_imports)]
-use crate::imu::old_asm330::{AccelFs, Odr, configure_imu, fs_a_to_g, fs_g_to_dps, poll_xl_gy_combined, read_status_data, GyroFs};
+use crate::imu::old_asm330::{
+    AccelFs, GyroFs, Odr, configure_imu, fs_a_to_g, fs_g_to_dps, poll_xl_gy_combined,
+    read_status_data,
+};
 use crate::types::ImuData;
 
 /// Start IMU task with a callback for each data sample
@@ -53,8 +56,16 @@ where
                             let gyro_x_dps = old_asm330::fs_g_to_dps(raw.gy.x, &gyro_fs);
                             let gyro_y_dps = old_asm330::fs_g_to_dps(raw.gy.y, &gyro_fs);
                             let gyro_z_dps = old_asm330::fs_g_to_dps(raw.gy.z, &gyro_fs);
-                            info!("TS: {} Accel: X={:.3}g Y={:.3}g Z={:.3}g Gyro: X={:.3}dps Y={:.3}dps Z={:.3}dps",
-                                raw.ts, accel_x_g, accel_y_g, accel_z_g, gyro_x_dps, gyro_y_dps, gyro_z_dps);
+                            info!(
+                                "TS: {} Accel: X={:.3}g Y={:.3}g Z={:.3}g Gyro: X={:.3}dps Y={:.3}dps Z={:.3}dps",
+                                raw.ts,
+                                accel_x_g,
+                                accel_y_g,
+                                accel_z_g,
+                                gyro_x_dps,
+                                gyro_y_dps,
+                                gyro_z_dps
+                            );
                             let imu_data = ImuData {
                                 accel_x: accel_x_g,
                                 accel_y: accel_y_g,
@@ -65,10 +76,15 @@ where
                             };
                             on_data(imu_data);
                         }
-                        Err(e) => { warn!("Failed to read combined XL/GY: {:?}", e); }
+                        Err(e) => {
+                            warn!("Failed to read combined XL/GY: {:?}", e);
+                        }
                     }
                 } else {
-                    trace!("Data not ready xlda={} gda={} tda={}", status.xlda, status.gda, status.tda);
+                    trace!(
+                        "Data not ready xlda={} gda={} tda={}",
+                        status.xlda, status.gda, status.tda
+                    );
                 }
             }
             Err(e) => {

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
@@ -1,12 +1,13 @@
-#[allow(unused_imports)]
 mod old_asm330;
 
+#[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
 use embassy_time::{Duration, Timer};
 
 use crate::SharedSpiDevice;
-use crate::imu::old_asm330::{AccelFs, Odr, fs_a_to_g, fs_g_to_dps, poll_xl_gy_combined, read_status_data, GyroFs};
+#[allow(unused_imports)]
+use crate::imu::old_asm330::{AccelFs, Odr, configure_imu, fs_a_to_g, fs_g_to_dps, poll_xl_gy_combined, read_status_data, GyroFs};
 use crate::types::ImuData;
 
 /// Start IMU task with a callback for each data sample
@@ -34,13 +35,9 @@ where
     let fsr_a = AccelFs::G8;
     let odr_a = Odr::Hz417;
     let gyro_fs = GyroFs::DPS1000;
-    let _ = old_asm330::set_xl_fsr(&mut spi, &fsr_a).await;
-    let _ = old_asm330::set_xl_odr(&mut spi, odr_a).await;
-    let _ = old_asm330::set_gyro_config(&mut spi, odr_a, gyro_fs).await;
-    // Ensure timestamp counter is enabled in CTRL10_C
-    match old_asm330::enable_timestamp(&mut spi).await {
-        Ok(()) => info!("Timestamp enabled"),
-        Err(e) => warn!("Failed to enable timestamp: {:?}", e),
+    match old_asm330::configure_imu(&mut spi, odr_a, fsr_a, gyro_fs, true).await {
+        Ok(()) => info!("IMU configured with BDU enabled"),
+        Err(e) => warn!("Failed to configure IMU: {:?}", e),
     }
 
     let period = Duration::from_hz(100);

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
@@ -31,9 +31,9 @@ where
             info!("SPI Error: {:?}", e);
         }
     }
-    let fsr_a = AccelFs::G4;
-    let odr_a = Odr::Hz104;
-    let gyro_fs = GyroFs::DPS250;
+    let fsr_a = AccelFs::G8;
+    let odr_a = Odr::Hz417;
+    let gyro_fs = GyroFs::DPS1000;
     let _ = old_asm330::set_xl_fsr(&mut spi, &fsr_a).await;
     let _ = old_asm330::set_xl_odr(&mut spi, odr_a).await;
     let _ = old_asm330::set_gyro_config(&mut spi, odr_a, gyro_fs).await;
@@ -43,7 +43,7 @@ where
         Err(e) => warn!("Failed to enable timestamp: {:?}", e),
     }
 
-    let period = Duration::from_hz(10);
+    let period = Duration::from_hz(100);
     loop {
         match old_asm330::read_status_data(&mut spi).await {
             Ok(status) => {

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
@@ -60,9 +60,9 @@ where
                             // Use global timebase to compute elapsed seconds since program start
                             let elapsed_s = timebase::elapsed_seconds();
                             info!(
-                                "TS: {} (raw) / {:.3}s Accel: X={:.3}g Y={:.3}g Z={:.3}g Gyro: X={:.3}dps Y={:.3}dps Z={:.3}dps",
-                                raw.ts,
+                                "t={:.3}s | TS={} Accel: X={:.3}g Y={:.3}g Z={:.3}g Gyro: X={:.3}dps Y={:.3}dps Z={:.3}dps",
                                 elapsed_s,
+                                raw.ts,
                                 accel_x_g,
                                 accel_y_g,
                                 accel_z_g,

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
@@ -1,11 +1,13 @@
 #[allow(unused_imports)]
+mod old_asm330;
+
 use log::{debug, error, info, trace, warn};
 
 use embassy_time::{Duration, Timer};
 
-use crate::old_asm330::{AccelFs, Odr};
+use crate::SharedSpiDevice;
+use crate::imu::old_asm330::{AccelFs, Odr, fs_a_to_g, fs_g_to_dps, poll_xl_gy_combined, read_status_data, GyroFs};
 use crate::types::ImuData;
-use crate::{SharedSpiDevice, old_asm330};
 
 /// Start IMU task with a callback for each data sample
 ///
@@ -29,42 +31,51 @@ where
             info!("SPI Error: {:?}", e);
         }
     }
-    let fsr_a = AccelFs::G2;
+    let fsr_a = AccelFs::G4;
     let odr_a = Odr::Hz104;
+    let gyro_fs = GyroFs::DPS250;
     let _ = old_asm330::set_xl_fsr(&mut spi, &fsr_a).await;
     let _ = old_asm330::set_xl_odr(&mut spi, odr_a).await;
+    let _ = old_asm330::set_gyro_config(&mut spi, odr_a, gyro_fs).await;
+    // Ensure timestamp counter is enabled in CTRL10_C
+    match old_asm330::enable_timestamp(&mut spi).await {
+        Ok(()) => info!("Timestamp enabled"),
+        Err(e) => warn!("Failed to enable timestamp: {:?}", e),
+    }
 
-    let period = Duration::from_hz(2);
+    let period = Duration::from_hz(10);
     loop {
-        match old_asm330::read_xl_xyz(&mut spi).await {
-            Ok(xl_raw_data) => {
-                debug!(
-                    "Got XL X: {}, Y: {}, Z: {}",
-                    xl_raw_data.x, xl_raw_data.y, xl_raw_data.z
-                );
-                let accel_x_g = old_asm330::fs_a_to_g(xl_raw_data.x, &fsr_a);
-                let accel_y_g = old_asm330::fs_a_to_g(xl_raw_data.y, &fsr_a);
-                let accel_z_g = old_asm330::fs_a_to_g(xl_raw_data.z, &fsr_a);
-
-                info!(
-                    "Accel: X={:.3}g Y={:.3}g Z={:.3}g",
-                    accel_x_g, accel_y_g, accel_z_g
-                );
-
-                // Invoke callback with IMU data
-                // Note: Gyro data is zeroed until driver supports gyroscope
-                let imu_data = ImuData {
-                    accel_x: accel_x_g,
-                    accel_y: accel_y_g,
-                    accel_z: accel_z_g,
-                    gyro_x: 0.0,
-                    gyro_y: 0.0,
-                    gyro_z: 0.0,
-                };
-                on_data(imu_data);
+        match old_asm330::read_status_data(&mut spi).await {
+            Ok(status) => {
+                if status.xlda && status.gda {
+                    match old_asm330::poll_xl_gy_combined(&mut spi).await {
+                        Ok(raw) => {
+                            let accel_x_g = old_asm330::fs_a_to_g(raw.xl.x, &fsr_a);
+                            let accel_y_g = old_asm330::fs_a_to_g(raw.xl.y, &fsr_a);
+                            let accel_z_g = old_asm330::fs_a_to_g(raw.xl.z, &fsr_a);
+                            let gyro_x_dps = old_asm330::fs_g_to_dps(raw.gy.x, &gyro_fs);
+                            let gyro_y_dps = old_asm330::fs_g_to_dps(raw.gy.y, &gyro_fs);
+                            let gyro_z_dps = old_asm330::fs_g_to_dps(raw.gy.z, &gyro_fs);
+                            info!("TS: {} Accel: X={:.3}g Y={:.3}g Z={:.3}g Gyro: X={:.3}dps Y={:.3}dps Z={:.3}dps",
+                                raw.ts, accel_x_g, accel_y_g, accel_z_g, gyro_x_dps, gyro_y_dps, gyro_z_dps);
+                            let imu_data = ImuData {
+                                accel_x: accel_x_g,
+                                accel_y: accel_y_g,
+                                accel_z: accel_z_g,
+                                gyro_x: gyro_x_dps,
+                                gyro_y: gyro_y_dps,
+                                gyro_z: gyro_z_dps,
+                            };
+                            on_data(imu_data);
+                        }
+                        Err(e) => { warn!("Failed to read combined XL/GY: {:?}", e); }
+                    }
+                } else {
+                    trace!("Data not ready xlda={} gda={} tda={}", status.xlda, status.gda, status.tda);
+                }
             }
             Err(e) => {
-                warn!("Failed to read XL XYZ: {:?}", e);
+                warn!("Failed to read status: {:?}", e);
             }
         }
         Timer::after(period).await;

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/mod.rs
@@ -4,6 +4,7 @@ mod old_asm330;
 use log::{debug, error, info, trace, warn};
 
 use embassy_time::{Duration, Timer};
+use crate::timebase;
 
 use crate::SharedSpiDevice;
 #[allow(unused_imports)]
@@ -56,9 +57,12 @@ where
                             let gyro_x_dps = old_asm330::fs_g_to_dps(raw.gy.x, &gyro_fs);
                             let gyro_y_dps = old_asm330::fs_g_to_dps(raw.gy.y, &gyro_fs);
                             let gyro_z_dps = old_asm330::fs_g_to_dps(raw.gy.z, &gyro_fs);
+                            // Use global timebase to compute elapsed seconds since program start
+                            let elapsed_s = timebase::elapsed_seconds();
                             info!(
-                                "TS: {} Accel: X={:.3}g Y={:.3}g Z={:.3}g Gyro: X={:.3}dps Y={:.3}dps Z={:.3}dps",
+                                "TS: {} (raw) / {:.3}s Accel: X={:.3}g Y={:.3}g Z={:.3}g Gyro: X={:.3}dps Y={:.3}dps Z={:.3}dps",
                                 raw.ts,
+                                elapsed_s,
                                 accel_x_g,
                                 accel_y_g,
                                 accel_z_g,

--- a/sw/sensor_board/sensor_board_rev1_test/src/imu/old_asm330.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/imu/old_asm330.rs
@@ -39,6 +39,8 @@ const REG_CTRL8_XL: u8 = 0x17;
 const REG_CTRL9_XL: u8 = 0x18;
 const REG_CTRL10_C: u8 = 0x19;
 
+const REG_STATUS_REG: u8 = 0x1E;
+
 const REG_OUTX_L_G: u8 = 0x22;
 const REG_OUTX_H_G: u8 = 0x23;
 const REG_OUTY_L_G: u8 = 0x24;
@@ -53,6 +55,11 @@ const REG_OUTY_H_A: u8 = 0x2B;
 const REG_OUTZ_L_A: u8 = 0x2C;
 const REG_OUTZ_H_A: u8 = 0x2D;
 
+const REG_TIMESTAMP0_REG: u8 = 0x40;
+const REG_TIMESTAMP1_REG: u8 = 0x41;
+const REG_TIMESTAMP2_REG: u8 = 0x42;
+const REG_TIMESTAMP3_REG: u8 = 0x43;
+
 // const REG_FIFO_DATA_OUT_X_L = 0x79;
 // const REG_FIFO_DATA_OUT_X_H = 0x7A;
 // const REG_FIFO_DATA_OUT_Y_L = 0x7B;
@@ -66,8 +73,10 @@ const GYRO_ODR_MASK: u8 = 0b1111_0000; // bits [7:4] in CTRL2_G
 const ACCEL_FSR_MASK: u8 = 0b0000_1100; // bits [3:2] in CTRL1_XL
 const ACCEL_ODR_MASK: u8 = 0b1111_0000; // bits [7:4] in CTRL1_XL
 
-const TIMER_EN_MASK: u8 = 0b0010_000; // Bit 5 in CTRL10_C
+const TIMER_EN_MASK: u8 = 0b0010_0000; // Bit 5 in CTRL10_C
 // TODO: Fix the way that our program communicates with the IMU lmao
+
+const BDU_MASK: u8 = 0b0100_0000; // Bit 6 in CTRL3_C (Block Data Update)
 
 const H_LACTIVE_MASK: u8 = 0b0010_0000; // Polarity: 0 = active high, 1 = active low
 const INT1_FIFO_TH_MASK: u8 = 0b0000_1000; // FIFO Watermark interrupt
@@ -125,36 +134,6 @@ pub enum Odr {
     Hz6667 = 0b1010_0000,
 }
 
-#[rustfmt::skip]
-#[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-pub enum FifoTsDec {
-    Off   = 0b0000_0000,
-    Dec1  = 0b0100_0000,
-    Dec8  = 0b1000_0000,
-    Dec32 = 0b1100_0000,
-}
-#[rustfmt::skip]
-#[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-pub enum FifoMode {
-    Bypass            = 0b0000_0000,
-    Fifo              = 0b0000_0001,
-    ContinuousToFifo  = 0b0000_0011,
-    BypassToContinuous= 0b0000_0100,
-    Continuous        = 0b0000_0110,
-    BypassToFifo      = 0b0000_0111,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct FifoConfig {
-    pub mode: FifoMode,     // Operation mode
-    pub watermark: u16,     // number of samples before flagging watermark
-    pub batch_rate_xl: Odr, // XL batch rate (match ODR)
-    pub batch_rate_gy: Odr, // GY batch rate (match ODR)
-    pub timestamp_decimation: FifoTsDec,
-}
-
 pub async fn check_who_am_i<S>(spi: &mut S) -> Result<u8, S::Error>
 where
     S: SpiDevice<u8>,
@@ -198,19 +177,6 @@ where
 ////////////////////////
 /// Configuration
 ////////////////////////
-pub async fn configure_interrupt_pin<S>(spi: &mut S) -> Result<(), S::Error>
-where
-    S: SpiDevice<u8>,
-    S::Error: core::fmt::Debug,
-{
-    // Active high interrupt
-    let current_ctrl3_c = read_register(spi, REG_CTRL3_C).await?;
-    let new_val = current_ctrl3_c | INT1_FIFO_TH_MASK;
-    write_register(spi, REG_INT1_CTRL, new_val).await?;
-
-    Ok(())
-}
-
 pub async fn enable_timestamp<S>(spi: &mut S) -> Result<(), S::Error>
 where
     S: SpiDevice<u8>,
@@ -220,72 +186,6 @@ where
     let new_ctrl10_c = current_ctrl10_c | TIMER_EN_MASK;
     write_register(spi, REG_CTRL10_C, new_ctrl10_c).await
 }
-
-////////////////////////
-/// FIFO
-////////////////////////
-pub async fn setup_fifo<S>(spi: &mut S, config: &FifoConfig) -> Result<(), S::Error>
-where
-    S: SpiDevice<u8>,
-    S::Error: core::fmt::Debug,
-{
-    // Set watermark (FIFO_CTRL2 [8], FIFO_CTRL1 [7:0])
-    let wm_lo = config.watermark as u8;
-    let wm_hi = (config.watermark >> 8) as u8;
-    let current_fifo_ctrl2 = read_register(spi, REG_FIFO_CTRL2).await?;
-    let new_fifo_ctrl2 = (current_fifo_ctrl2 & !WTM8_MASK) | wm_hi;
-    write_register(spi, REG_FIFO_CTRL1, wm_lo).await?;
-    write_register(spi, REG_FIFO_CTRL2, new_fifo_ctrl2).await?;
-
-    // Set batch data rates for XL and GY (FIFO_CTRL3)
-    // gy gy gy gy xl xl xl xl
-    let new_fifo_ctrl3 = config.batch_rate_gy as u8 | ((config.batch_rate_xl as u8) >> 4);
-    write_register(spi, REG_FIFO_CTRL3, new_fifo_ctrl3).await?;
-
-    // Timestamp decimation, fifo mode
-    // TODO: this currently ignores temp batching since it makes the parsing a bit more difficult
-    let new_fifo_ctrl4 = config.timestamp_decimation as u8 | config.mode as u8;
-    write_register(spi, REG_FIFO_CTRL4, new_fifo_ctrl4).await?;
-
-    Ok(())
-}
-
-// pub fn read_fifo_batch<S>(
-//     spi: &mut S,
-//     raw_samples: &mut [RawImuData],
-//     fifo_depth: usize,
-// ) -> Result<usize, S::Error>
-// where
-//     S: SpiDevice<u8>,
-//     S::Error: core::fmt::Debug,
-// {
-//     // Limit how many we read to the buffer size
-//     let max_buf_size = fifo_depth.min(raw_samples.len());
-//
-//     for i in 0..max_buf_size {
-//         raw_samples[i] = get_from_fifo(spi)?;
-//     }
-//
-//     Ok(max_buf_size)
-// }
-//
-// fn get_from_fifo<S>(spi: &mut S) -> Result<RawImuData, S::Error>
-// where
-//     S: SpiDevice<u8>,
-//     S::Error: core::fmt::Debug,
-// {
-//     const READ_CMD: u8 = 0x80 | REG_FIFO_DATA_OUT_X_L; // start at the FIRST fifo reg
-//     let mut buffer: [u8; 16] = [READ_CMD, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-//     spi.transfer_in_place(&mut buffer)?;
-//     let ts_low = buffer[13];
-//     let ts_mid = buffer[14];
-//     let ts_high = buffer[15];
-//     Ok(RawImuData {
-//         gy.x: i16::from_le_bytes(buffer[1], buffer[2]),
-//         gyro_y: i16::from_le_bytes(buffer[3], buffer[4]),
-//         gyro_z: i16::from_le_bytes(buffer[5], buffer[6]),
-//     })
-// }
 
 ////////////////////////
 /// Gyro
@@ -332,7 +232,6 @@ where
 ////////////////////////
 /// Accelerometer
 ////////////////////////
-
 pub fn fs_a_to_g(raw: i16, fsr: &AccelFs) -> f32 {
     let sensitivity_mg = match fsr {
         AccelFs::G2 => 0.061,
@@ -342,6 +241,19 @@ pub fn fs_a_to_g(raw: i16, fsr: &AccelFs) -> f32 {
     };
 
     ((raw as f32) * sensitivity_mg) / 1000.0
+}
+
+pub fn fs_g_to_dps(raw: i16, fsr: &GyroFs) -> f32 {
+    // Sensitivities in mdps/LSB (millidegrees per second per LSB)
+    let sensitivity_mdps = match fsr {
+        GyroFs::DPS250 => 8.75,
+        GyroFs::DPS500 => 17.50,
+        GyroFs::DPS1000 => 35.0,
+        GyroFs::DPS2000 => 70.0,
+    };
+
+    // Convert millidegrees/sec to degrees/sec
+    ((raw as f32) * sensitivity_mdps) / 1000.0
 }
 
 pub async fn set_xl_fsr<S>(spi: &mut S, fsr: &AccelFs) -> Result<(), S::Error>
@@ -449,4 +361,123 @@ where
     let z_raw = i16::from_le_bytes([z_lo, z_hi]);
 
     Ok(z_raw)
+}
+
+pub async fn read_gy_xyz<S>(spi: &mut S) -> Result<GyRawData, S::Error>
+where
+    S: SpiDevice<u8>,
+    S::Error: core::fmt::Debug,
+{
+    debug!("Attempting to read raw GY XYZ registers");
+    const READ_CMD: u8 = 0x80 | REG_OUTX_L_G;
+    // Need 7 bytes: 1 command + 6 data bytes (X_L, X_H, Y_L, Y_H, Z_L, Z_H)
+    let mut buf: [u8; 7] = [READ_CMD, 0, 0, 0, 0, 0, 0];
+    spi.transfer_in_place(&mut buf).await?;
+
+    let x = i16::from_le_bytes([buf[1], buf[2]]);
+    let y = i16::from_le_bytes([buf[3], buf[4]]);
+    let z = i16::from_le_bytes([buf[5], buf[6]]);
+
+    Ok(GyRawData { x, y, z })
+}
+
+/// Configure both accelerometer (XL) and gyroscope (GY) ODR and FS ranges.
+/// Also enables the sensor timestamp counter.
+pub async fn configure_imu<S>(
+    spi: &mut S,
+    odr: Odr,
+    accel_fs: AccelFs,
+    gyro_fs: GyroFs,
+    enable_bdu: bool,
+) -> Result<(), S::Error>
+where
+    S: SpiDevice<u8>,
+    S::Error: core::fmt::Debug,
+{
+    // Set accelerometer ODR and full-scale range
+    set_xl_odr(spi, odr).await?;
+    set_xl_fsr(spi, &accel_fs).await?;
+
+    // Set gyroscope ODR and full-scale range
+    set_gyro_config(spi, odr, gyro_fs).await?;
+
+    // Enable sensor timestamp so we can read timestamps when polling
+    enable_timestamp(spi).await?;
+
+    // Configure Block Data Update if requested
+    let current_ctrl3 = read_register(spi, REG_CTRL3_C).await?;
+    let new_ctrl3 = if enable_bdu {
+        current_ctrl3 | BDU_MASK
+    } else {
+        current_ctrl3 & !BDU_MASK
+    };
+    write_register(spi, REG_CTRL3_C, new_ctrl3).await?;
+
+    Ok(())
+}
+
+/// Poll both accelerometer and gyroscope and return combined raw data with a timestamp.
+pub async fn poll_xl_gy_combined<S>(spi: &mut S) -> Result<RawImuData, S::Error>
+where
+    S: SpiDevice<u8>,
+    S::Error: core::fmt::Debug,
+{
+    debug!("Attempting combined SPI read for GY then XL registers");
+    const READ_CMD: u8 = 0x80 | REG_OUTX_L_G;
+    // 1 command byte + 12 data bytes (GY X/Y/Z, XL X/Y/Z)
+    let mut buf: [u8; 13] = [READ_CMD, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    spi.transfer_in_place(&mut buf).await?;
+
+    let gx = i16::from_le_bytes([buf[1], buf[2]]);
+    let gyy = i16::from_le_bytes([buf[3], buf[4]]);
+    let gz = i16::from_le_bytes([buf[5], buf[6]]);
+    let ax = i16::from_le_bytes([buf[7], buf[8]]);
+    let ay = i16::from_le_bytes([buf[9], buf[10]]);
+    let az = i16::from_le_bytes([buf[11], buf[12]]);
+
+    let gyro = GyRawData {
+        x: gx,
+        y: gyy,
+        z: gz,
+    };
+    let xl = XlRawData {
+        x: ax,
+        y: ay,
+        z: az,
+    };
+
+    let ts = get_timestamp(spi).await?;
+
+    Ok(RawImuData { xl, gy: gyro, ts })
+}
+
+pub async fn get_timestamp<S>(spi: &mut S) -> Result<u32, S::Error>
+where
+    S: SpiDevice<u8>,
+    S::Error: core::fmt::Debug,
+{
+    const READ_CMD: u8 = 0x80 | REG_TIMESTAMP0_REG;
+    let mut buf: [u8; 5] = [READ_CMD, 0, 0, 0, 0];
+    spi.transfer_in_place(&mut buf).await?;
+    let ts = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]);
+    Ok(ts)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct StatusDataAvailable {
+    pub xlda: bool,
+    pub gda: bool,
+    pub tda: bool,
+}
+
+pub async fn read_status_data<S>(spi: &mut S) -> Result<StatusDataAvailable, S::Error>
+where
+    S: SpiDevice<u8>,
+    S::Error: core::fmt::Debug,
+{
+    let status = read_register(spi, REG_STATUS_REG).await?;
+    let xlda = (status & 0b0000_0001) != 0;
+    let gda = (status & 0b0000_0010) != 0;
+    let tda = (status & 0b0000_0100) != 0;
+    Ok(StatusDataAvailable { xlda, gda, tda })
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -22,7 +22,6 @@ pub mod gps;
 pub mod hmi;
 #[cfg(feature = "imu")]
 pub mod imu;
-pub mod old_asm330;
 pub mod types;
 pub mod usb;
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -16,6 +16,7 @@ use esp_hal::usb_serial_jtag::UsbSerialJtagTx;
 pub mod aircomm;
 pub mod app;
 pub mod asm330;
+pub mod timebase;
 #[cfg(feature = "gps")]
 pub mod gps;
 #[cfg(feature = "hmi")]

--- a/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
@@ -1,0 +1,25 @@
+use core::sync::atomic::{AtomicU32, Ordering};
+use embassy_time::Instant;
+
+// Program start timestamp in milliseconds since an arbitrary epoch (Instant::now()).
+// Using u32 to remain compatible with no_std targets; overflow after ~49 days.
+static PROGRAM_START_MS: AtomicU32 = AtomicU32::new(0);
+
+/// Initialize the program start time (call once early during startup)
+pub fn set_program_start() {
+    let now_ms = (Instant::now().as_millis() as u64) as u32;
+    PROGRAM_START_MS.store(now_ms, Ordering::SeqCst);
+}
+
+/// Returns the program start timestamp (milliseconds)
+pub fn program_start_ms() -> u32 {
+    PROGRAM_START_MS.load(Ordering::SeqCst)
+}
+
+/// Returns elapsed seconds (as f32) since program start using Instant::now()
+pub fn elapsed_seconds() -> f32 {
+    let now_ms = (Instant::now().as_millis() as u64) as u32;
+    let start = PROGRAM_START_MS.load(Ordering::SeqCst);
+    let elapsed_ms = now_ms.wrapping_sub(start) as u32;
+    (elapsed_ms as f32) / 1000.0
+}


### PR DESCRIPTION
Uses the Old ASM330 driver to hard-poll IMU data.

Also happes to:
- bring some changes to the GPS driver to remove the warnings we get when running `cargo build`
- introduce a global timebase (so we can compare when GPS/IMU logs are going)

**Note:** We still want Eugene's proper IMU driver if we can since that gives us proper FIFO batching (reduces SPI bus congestion), as well as guaranteed-rate IMU data (the IMU itself is going to clock data on a 100hz rising edge, so our data is more consistent). His PR should also bring in proper IMU management (re: filtering).

This *should* be usable for now but it is definitely FAR from ideal.