### PR TITLE
USB Fixes

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "esp-rtos",
  "heapless 0.9.2",
  "log",
+ "nb 1.1.0",
  "nmea-parser",
  "static_cell",
 ]

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -56,7 +56,7 @@ esp-hal = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package 
 esp-rtos = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-rtos", features = ["esp32c6", "esp-alloc", "embassy", "esp-radio"] }
 esp-alloc = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-alloc" }
 esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-bootloader-esp-idf", features = ["esp32c6"] }
-esp-println = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-println", features = ["esp32c6", "log-04"] }
+esp-println = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-println", default-features = false, features = ["esp32c6", "log-04", "jtag-serial", "colors", "critical-section"] }
 
 # ESP-NOW wireless communication
 esp-radio = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-radio", features = ["esp32c6", "esp-now", "unstable", "esp-alloc"] }

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -10,7 +10,7 @@ default-run  = "rev1_board"
 
 [features]
 default = ["hmi", "imu", "gps", "wifi"]
-bridge  = ["usb", "wifi"]
+bridge  = ["hmi", "usb", "wifi"]
 hmi = []      # User LED, NeoPixel, Display
 imu = []      # IMU sensor (SPI)
 gps = []      # GPS sensor (UART)
@@ -70,6 +70,7 @@ nmea-parser = { path = "../../Drivers/nmea-parser/", default-features = false, f
 heapless = "0.9.2"
 byteorder = { version = "1.5", default-features = false }
 cobs = { version = "0.3", default-features = false }
+nb = "1.1.0"
 embassy-embedded-hal = "0.5.0"
 static_cell = "2.1.1"
 embassy-sync = "0.7.2"

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -32,7 +32,7 @@ use crate::imu::start_imu;
 #[cfg(all(feature = "wifi", feature = "usb"))]
 use crate::types::NodeId;
 #[cfg(feature = "usb")]
-use crate::usb::{MAX_USB_MESSAGE_SIZE, UsbSerial, format_mac, serialize_forwarded_message};
+use crate::usb::{MAX_USB_MESSAGE_SIZE, UsbError, UsbSerial, format_mac, serialize_forwarded_message, wait_for_usb_host};
 
 /// Capacity of the sensor data channel
 /// Allows buffering sensor samples while ESP-NOW sends
@@ -121,6 +121,9 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
                             info!("ESP-NOW mode: Bridge (receive + forward to USB)");
                             if let Some(usb_tx) = board.take_usb_serial_tx() {
                                 let usb_serial = UsbSerial::new(usb_tx);
+                                info!("[BRIDGE] Waiting for USB host before starting");
+                                wait_for_usb_host().await;
+                                info!("[BRIDGE] USB host detected - starting bridge task");
                                 spawner
                                     .spawn(espnow_bridge_task(
                                         transceiver,
@@ -405,6 +408,9 @@ async fn espnow_bridge_task(
                                     format_mac(&src_mac),
                                     messages_forwarded
                                 );
+                            }
+                            Err(UsbError::NotReady) => {
+                                // Drop silently when USB host is not ready.
                             }
                             Err(e) => {
                                 errors += 1;

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -32,7 +32,7 @@ use crate::imu::start_imu;
 #[cfg(all(feature = "wifi", feature = "usb"))]
 use crate::types::NodeId;
 #[cfg(feature = "usb")]
-use crate::usb::{MAX_USB_MESSAGE_SIZE, UsbError, UsbSerial, format_mac, serialize_forwarded_message, wait_for_usb_host};
+use crate::usb::{MAX_USB_MESSAGE_SIZE, UsbError, UsbSerial, format_mac, serialize_forwarded_message, wait_for_usb_host_timeout};
 
 /// Capacity of the sensor data channel
 /// Allows buffering sensor samples while ESP-NOW sends
@@ -122,8 +122,15 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
                             if let Some(usb_tx) = board.take_usb_serial_tx() {
                                 let usb_serial = UsbSerial::new(usb_tx);
                                 info!("[BRIDGE] Waiting for USB host before starting");
-                                wait_for_usb_host().await;
-                                info!("[BRIDGE] USB host detected - starting bridge task");
+                                let host_ready =
+                                    wait_for_usb_host_timeout(Duration::from_secs(3)).await;
+                                if host_ready {
+                                    info!("[BRIDGE] USB host detected - starting bridge task");
+                                } else {
+                                    warn!(
+                                        "[BRIDGE] USB host not detected - starting anyway"
+                                    );
+                                }
                                 spawner
                                     .spawn(espnow_bridge_task(
                                         transceiver,

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -252,6 +252,13 @@ async fn main(spawner: embassy_executor::Spawner) {
 
     let board = DevkitC::from_peripherals(peripherals);
 
+    // Wait for USB host to enumerate after reset/power cycle.
+    // Without this delay, the USB-JTAG peripheral may not be ready
+    // and writes will fail silently after a reset (but work after flash).
+    log::info!("Waiting for USB enumeration...");
+    embassy_time::Timer::after(embassy_time::Duration::from_millis(2000)).await;
+    log::info!("USB enumeration delay complete, starting app");
+
     app_run(spawner, board).await;
     loop {
         embassy_time::Timer::after_secs(1).await

--- a/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
@@ -1,25 +1,29 @@
-use core::sync::atomic::{AtomicU32, Ordering};
 use embassy_time::Instant;
 
 // Program start timestamp in milliseconds since an arbitrary epoch (Instant::now()).
-// Using u32 to remain compatible with no_std targets; overflow after ~49 days.
-static PROGRAM_START_MS: AtomicU32 = AtomicU32::new(0);
+// This is safe because we only write once at startup (set_program_start)
+// and read many times afterwards. Single-threaded embedded environment.
+static mut PROGRAM_START_MS: u64 = 0;
 
 /// Initialize the program start time (call once early during startup)
 pub fn set_program_start() {
-    let now_ms = (Instant::now().as_millis() as u64) as u32;
-    PROGRAM_START_MS.store(now_ms, Ordering::SeqCst);
+    // SAFETY: Safe because called once at startup before any other threads access it
+    unsafe {
+        PROGRAM_START_MS = Instant::now().as_millis();
+    }
 }
 
 /// Returns the program start timestamp (milliseconds)
-pub fn program_start_ms() -> u32 {
-    PROGRAM_START_MS.load(Ordering::SeqCst)
+pub fn program_start_ms() -> u64 {
+    // SAFETY: Safe for reading as-is in single-threaded context
+    unsafe { PROGRAM_START_MS }
 }
 
 /// Returns elapsed seconds (as f32) since program start using Instant::now()
 pub fn elapsed_seconds() -> f32 {
-    let now_ms = (Instant::now().as_millis() as u64) as u32;
-    let start = PROGRAM_START_MS.load(Ordering::SeqCst);
-    let elapsed_ms = now_ms.wrapping_sub(start) as u32;
+    let now_ms = Instant::now().as_millis();
+    // SAFETY: Safe for reading as-is in single-threaded context
+    let start = unsafe { PROGRAM_START_MS };
+    let elapsed_ms = now_ms - start;
     (elapsed_ms as f32) / 1000.0
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
@@ -1,29 +1,25 @@
+use core::sync::atomic::{AtomicU32, Ordering};
 use embassy_time::Instant;
 
 // Program start timestamp in milliseconds since an arbitrary epoch (Instant::now()).
-// This is safe because we only write once at startup (set_program_start)
-// and read many times afterwards. Single-threaded embedded environment.
-static mut PROGRAM_START_MS: u64 = 0;
+// Using u32 to remain compatible with no_std targets; overflow after ~49 days.
+static PROGRAM_START_MS: AtomicU32 = AtomicU32::new(0);
 
 /// Initialize the program start time (call once early during startup)
 pub fn set_program_start() {
-    // SAFETY: Safe because called once at startup before any other threads access it
-    unsafe {
-        PROGRAM_START_MS = Instant::now().as_millis();
-    }
+    let now_ms = (Instant::now().as_millis() as u64) as u32;
+    PROGRAM_START_MS.store(now_ms, Ordering::SeqCst);
 }
 
 /// Returns the program start timestamp (milliseconds)
-pub fn program_start_ms() -> u64 {
-    // SAFETY: Safe for reading as-is in single-threaded context
-    unsafe { PROGRAM_START_MS }
+pub fn program_start_ms() -> u32 {
+    PROGRAM_START_MS.load(Ordering::SeqCst)
 }
 
 /// Returns elapsed seconds (as f32) since program start using Instant::now()
 pub fn elapsed_seconds() -> f32 {
-    let now_ms = Instant::now().as_millis();
-    // SAFETY: Safe for reading as-is in single-threaded context
-    let start = unsafe { PROGRAM_START_MS };
-    let elapsed_ms = now_ms - start;
+    let now_ms = (Instant::now().as_millis() as u64) as u32;
+    let start = PROGRAM_START_MS.load(Ordering::SeqCst);
+    let elapsed_ms = now_ms.wrapping_sub(start) as u32;
     (elapsed_ms as f32) / 1000.0
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
@@ -8,6 +8,8 @@
 pub mod protocol;
 
 use esp_hal::Async;
+use embassy_time::{Duration, Instant, Timer};
+use nb::Error as NbError;
 use esp_hal::usb_serial_jtag::UsbSerialJtagTx;
 
 pub use protocol::{ForwardError, MAX_USB_MESSAGE_SIZE, format_mac, serialize_forwarded_message};
@@ -21,6 +23,9 @@ pub const MAX_MESSAGE_SIZE: usize = 128;
 
 /// COBS encoding adds at most 1 byte per 254 bytes, plus 1 overhead byte and 1 delimiter (0x00)
 pub const MAX_ENCODED_SIZE: usize = MAX_MESSAGE_SIZE + (MAX_MESSAGE_SIZE / 254) + 2;
+const USB_WRITE_TIMEOUT: Duration = Duration::from_millis(30);
+const USB_WRITE_RETRY_DELAY: Duration = Duration::from_micros(250);
+const USB_HOST_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// USB Serial writer with COBS framing support
 pub struct UsbSerial {
@@ -57,14 +62,17 @@ impl UsbSerial {
         // COBS encode the data
         let encoded_len = cobs::encode(data, &mut self.encode_buffer);
 
-        // Write the encoded data
-        self.tx.write(&self.encode_buffer[..encoded_len]).unwrap();
+        // Write the encoded data (non-blocking with timeout to avoid hanging when USB is idle)
+        for i in 0..encoded_len {
+            let byte = self.encode_buffer[i];
+            self.write_byte_with_timeout(byte).await?;
+        }
 
         // Write the frame delimiter (0x00)
-        self.tx.write(&[0x00]).unwrap();
+        self.write_byte_with_timeout(0x00).await?;
 
         // Flush to ensure data is sent
-        self.tx.flush_tx().unwrap();
+        self.flush_with_timeout().await?;
 
         trace!(
             "[USB] Sent {} bytes ({} encoded + delimiter)",
@@ -82,6 +90,52 @@ impl UsbSerial {
         self.tx.flush_tx().unwrap();
         Ok(())
     }
+
+    async fn write_byte_with_timeout(&mut self, byte: u8) -> Result<(), UsbError> {
+        let start = Instant::now();
+        loop {
+            match self.tx.write_byte_nb(byte) {
+                Ok(()) => return Ok(()),
+                Err(NbError::WouldBlock) => {
+                    if start.elapsed() >= USB_WRITE_TIMEOUT {
+                        return Err(UsbError::NotReady);
+                    }
+                    Timer::after(USB_WRITE_RETRY_DELAY).await;
+                }
+                Err(NbError::Other(_)) => return Err(UsbError::NotReady),
+            }
+        }
+    }
+
+    async fn flush_with_timeout(&mut self) -> Result<(), UsbError> {
+        let start = Instant::now();
+        loop {
+            match self.tx.flush_tx_nb() {
+                Ok(()) => return Ok(()),
+                Err(NbError::WouldBlock) => {
+                    if start.elapsed() >= USB_WRITE_TIMEOUT {
+                        return Err(UsbError::NotReady);
+                    }
+                    Timer::after(USB_WRITE_RETRY_DELAY).await;
+                }
+                Err(NbError::Other(_)) => return Err(UsbError::NotReady),
+            }
+        }
+    }
+}
+
+/// Wait until a USB host is detected (ESP32-C6 USB Serial/JTAG SOF flag).
+pub async fn wait_for_usb_host() {
+    while !usb_host_connected() {
+        Timer::after(USB_HOST_POLL_INTERVAL).await;
+    }
+}
+
+fn usb_host_connected() -> bool {
+    // USB_DEVICE_INT_RAW register for ESP32-C6. SOF bit indicates host traffic.
+    const USB_DEVICE_INT_RAW: *const u32 = 0x6000_f008 as *const u32;
+    const SOF_INT_MASK: u32 = 0b10;
+    unsafe { (USB_DEVICE_INT_RAW.read_volatile() & SOF_INT_MASK) != 0 }
 }
 
 /// USB Serial errors
@@ -89,4 +143,6 @@ impl UsbSerial {
 pub enum UsbError {
     /// Message exceeds maximum allowed size
     MessageTooLarge,
+    /// USB host not ready (avoid blocking forever when not connected)
+    NotReady,
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
@@ -125,10 +125,15 @@ impl UsbSerial {
 }
 
 /// Wait until a USB host is detected (ESP32-C6 USB Serial/JTAG SOF flag).
-pub async fn wait_for_usb_host() {
+pub async fn wait_for_usb_host_timeout(timeout: Duration) -> bool {
+    let start = Instant::now();
     while !usb_host_connected() {
+        if start.elapsed() >= timeout {
+            return false;
+        }
         Timer::after(USB_HOST_POLL_INTERVAL).await;
     }
+    true
 }
 
 fn usb_host_connected() -> bool {


### PR DESCRIPTION
# Issues
- USB forwards the message in the first flash (observable via --monitor). USB doesn't forward the message if powercycle/reset.
- USB writes blocks the whole program when the usb host isn't connected
#  Fixes
- Added non-blocking USB write and flush with timeouts and retries
- Added detection to usb host through SOF (start of frame) flag
- Added a delay before the start of apps that waits for the usb connection to be ready