### PR TITLE
GPS High Baud Rate + GPS Light Pattern Update

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -9,7 +9,7 @@ version      = "0.1.0"
 default-run  = "rev1_board"
 
 [features]
-default = ["hmi", "imu", "gps", "wifi"]
+default = ["hmi", "imu", "gps", "wifi", "set_gps_high_baud", "set_gps_10hz"]
 bridge  = ["hmi", "usb", "wifi"]
 hmi = []      # User LED, NeoPixel, Display
 imu = []      # IMU sensor (SPI)

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -1,7 +1,6 @@
 /// app.rs
 /// responsible for starting the "app" and setting any necessary configs
-
-use embassy_time::{Duration, Timer, Instant};
+use embassy_time::{Duration, Instant, Timer};
 #[cfg(feature = "hmi")]
 use esp_hal::gpio::Output;
 
@@ -29,7 +28,10 @@ use crate::imu::start_imu;
 #[cfg(all(feature = "wifi", feature = "usb"))]
 use crate::types::NodeId;
 #[cfg(feature = "usb")]
-use crate::usb::{MAX_USB_MESSAGE_SIZE, UsbError, UsbSerial, format_mac, serialize_forwarded_message, wait_for_usb_host_timeout};
+use crate::usb::{
+    MAX_USB_MESSAGE_SIZE, UsbError, UsbSerial, format_mac, serialize_forwarded_message,
+    wait_for_usb_host_timeout,
+};
 
 /// Capacity of the sensor data channel
 /// Allows buffering sensor samples while ESP-NOW sends
@@ -151,7 +153,8 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
                                 info!("[BRIDGE] Waiting for USB host before starting");
                                 // Wait for USB host with neopixel animation for visual feedback
                                 {
-                                    const USB_DEVICE_INT_RAW: *const u32 = 0x6000_f008 as *const u32;
+                                    const USB_DEVICE_INT_RAW: *const u32 =
+                                        0x6000_f008 as *const u32;
                                     const SOF_INT_MASK: u32 = 0b10;
                                     let start = Instant::now();
                                     let timeout = Duration::from_secs(3);
@@ -170,9 +173,12 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
                                             (pos * 3, 0, 255 - pos * 3)
                                         }
                                     }
-                                    let total_steps = (timeout.as_millis() / step.as_millis()) as u32;
+                                    let total_steps =
+                                        (timeout.as_millis() / step.as_millis()) as u32;
                                     while start.elapsed() < timeout {
-                                        let connected = unsafe { (USB_DEVICE_INT_RAW.read_volatile() & SOF_INT_MASK) != 0 };
+                                        let connected = unsafe {
+                                            (USB_DEVICE_INT_RAW.read_volatile() & SOF_INT_MASK) != 0
+                                        };
                                         if connected {
                                             host_ready = true;
                                             break;
@@ -180,7 +186,10 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
                                         let pos = ((i * 256 / (total_steps.max(1))) % 256) as u8;
                                         let (r, g, b) = wheel(pos);
                                         neopixel
-                                            .set_color_with_brightness(crate::hmi::Color::Custom(r, g, b), 50)
+                                            .set_color_with_brightness(
+                                                crate::hmi::Color::Custom(r, g, b),
+                                                50,
+                                            )
                                             .await;
                                         Timer::after(step).await;
                                         i = i.wrapping_add(1);
@@ -383,11 +392,17 @@ async fn espnow_sender_task(
 
                 let result = match &payload {
                     SensorPayload::Imu(data) => {
-                        debug!("[ESP-NOW TX] Sending IMU data");
+                        info!(
+                            "[ESP-NOW TX] Sending IMU data, timestamp_us={}",
+                            timestamp_us
+                        );
                         transceiver.send_imu(timestamp_us, data, &BROADCAST).await
                     }
                     SensorPayload::Gps(data) => {
-                        debug!("[ESP-NOW TX] Sending GPS data");
+                        info!(
+                            "[ESP-NOW TX] Sending GPS data, timestamp_us={}",
+                            timestamp_us
+                        );
                         transceiver.send_gps(timestamp_us, data, &BROADCAST).await
                     }
                     SensorPayload::Heartbeat(data) => {

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -179,6 +179,12 @@ where
                 continue;
             }
         };
+
+        if n > 0 {
+            let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+            hmi.last_gps_rx_timestamp = Some(Instant::now());
+        }
+
         let chunk = core::str::from_utf8(&buf[..n]).unwrap_or("");
 
         if incomplete_line_buffer.push_str(chunk).is_err() {

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -110,11 +110,27 @@ pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uar
 
     #[cfg(feature = "set_gps_high_baud")]
     {
-        // This sets baud to 460800
-        // default for M8 is 9600, default for F10 is 38400. Reset to default, set high baud, then set
-        // high baud. Theoretically we can reconfigure the uart on the fly by dropping and re-creating
-        // but that seems really difficult and I don't want to do that
-        send_nmea_command(&mut gps2_uart, "PUBX,41,1,3,3,460800,0", "SET BAUD 460800").await;
+        info!("Setting GPS Baud to 460800 (Persistent)...");
+        
+        // Key ID for CFG-UART1-BAUDRATE: 0x40520001
+        // Value for 460800: 0x00070800 (Little Endian: 0x00, 0x08, 0x07, 0x00)
+        const UBX_CFG_VALSET_BAUD_460800: [u8; 12] = [
+            0x00,       // Version 0
+            0x07,       // Layer: 7 = RAM + Flash + BBR (Persistent)
+            0x00, 0x00, // Reserved
+            0x01, 0x00, 0x52, 0x40, // Key ID: CFG-UART1-BAUDRATE
+            0x00, 0x08, 0x07, 0x00  // Value: 460800
+        ];
+
+        send_ubx_packet(
+            &mut gps2_uart,
+            0x06, // class: CFG
+            0x8A, // id: VALSET
+            &UBX_CFG_VALSET_BAUD_460800,
+            "CFG-UART1-BAUDRATE"
+        ).await;
+
+        info!("ESP32 UART switched to 460800 baud.");
     }
 
     #[cfg(feature = "set_gps_10hz")]

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -226,14 +226,26 @@ where
                     Ok(parsed_data) => match parsed_data {
                         nmea_parser::ParsedMessage::Gga(gga) => {
                             let elapsed_s = crate::timebase::elapsed_seconds();
-                            info!(
-                                "t={:.3}s GPGGA FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
-                                elapsed_s,
-                                gga.latitude.unwrap_or(0.0),
-                                gga.longitude.unwrap_or(0.0),
-                                gga.hdop.unwrap_or(0.0),
-                                gga.satellite_count.unwrap_or(0),
-                            );
+                            let has_fix = gga.latitude.is_some() && gga.longitude.is_some();
+                            let sat_count = gga.satellite_count.unwrap_or(0);
+                            
+                            if has_fix {
+                                info!(
+                                    "t={:.3}s GPGGA ✓ VALID FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
+                                    elapsed_s,
+                                    gga.latitude.unwrap_or(0.0),
+                                    gga.longitude.unwrap_or(0.0),
+                                    gga.hdop.unwrap_or(0.0),
+                                    sat_count,
+                                );
+                            } else {
+                                warn!(
+                                    "t={:.3}s GPGGA ✗ NO FIX: SATS={}, HDOP={}",
+                                    elapsed_s,
+                                    sat_count,
+                                    gga.hdop.unwrap_or(99.99),
+                                );
+                            }
 
                             // Update cached values from GGA
                             if let Some(lat) = gga.latitude {
@@ -260,7 +272,8 @@ where
                             // Update HMI state: GPS timestamp and fix flag
                             let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
                             hmi.last_gps_timestamp = Some(Instant::now());
-                            hmi.gps_fix = true;
+                            // Only set fix=true if we have valid position data
+                            hmi.gps_fix = gga.latitude.is_some() && gga.longitude.is_some();
                         }
                         nmea_parser::ParsedMessage::Rmc(rmc) => {
                             if let Some(time) = rmc.timestamp {

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -24,7 +24,10 @@ pub async fn start_hmi(
 
     let mut led_on = false;
 
+    let mut slow_blink_on = false;
+
     loop {
+        let tick_start = Instant::now();
         trace!("[HMI] - Heartbeat OK");
 
         // Toggle user LED as heartbeat
@@ -36,7 +39,7 @@ pub async fn start_hmi(
         led_on = !led_on;
 
         // Read HMI state to decide NeoPixel behaviour
-        let mut state = crate::hmi::state::HMI_STATE.0.lock().await;
+        let state = crate::hmi::state::HMI_STATE.0.lock().await;
         let now = Instant::now();
 
         // Determine IMU age and color
@@ -53,30 +56,57 @@ pub async fn start_hmi(
             Color::Red
         };
 
-        // Determine GPS blink vs solid
-        let gps_fix = state.gps_fix;
-        let gps_blink = if let Some(_last_gps) = state.last_gps_timestamp {
-            // If gps_fix is false -> blink; if true -> solid
-            !gps_fix
-        } else {
-            // No GPS data yet -> initializing -> blink
-            true
-        };
+        // Determine GPS connection vs fix status
+        let gps_rx_recent = state
+            .last_gps_rx_timestamp
+            .map(|ts| now.duration_since(ts).as_secs() <= 3)
+            .unwrap_or(false);
+        let gps_fix_recent = state.gps_fix
+            && state
+                .last_gps_timestamp
+                .map(|ts| now.duration_since(ts).as_secs() <= 3)
+                .unwrap_or(false);
         drop(state);
 
-        if gps_blink {
-            // Blink: alternate between color and off each heartbeat
-            neopixel.set_color_with_brightness(color, neopixel_brightness).await;
-            Timer::after(period).await;
-            neopixel.clear().await;
-        } else {
-            // Solid color
+        let period_ms = period.as_millis().max(1) as u64;
+        let fast_pulse_ms = (period_ms / 4).max(1);
+        let fast_pulse = Duration::from_millis(fast_pulse_ms);
+        let fast_gap = fast_pulse;
+
+        if gps_fix_recent {
+            // GPS fix -> solid
             neopixel
                 .set_color_with_brightness(color, neopixel_brightness)
                 .await;
+        } else if gps_rx_recent {
+            // GPS connected, no fix -> fast blink (double pulse)
+            neopixel
+                .set_color_with_brightness(color, neopixel_brightness)
+                .await;
+            Timer::after(fast_pulse).await;
+            neopixel.clear().await;
+            Timer::after(fast_gap).await;
+            neopixel
+                .set_color_with_brightness(color, neopixel_brightness)
+                .await;
+            Timer::after(fast_pulse).await;
+            neopixel.clear().await;
+        } else {
+            // No GPS data -> slow blink
+            slow_blink_on = !slow_blink_on;
+            if slow_blink_on {
+                neopixel
+                    .set_color_with_brightness(color, neopixel_brightness)
+                    .await;
+            } else {
+                neopixel.clear().await;
+            }
         }
 
         // Wait for the next heartbeat tick
-        Timer::after(period).await;
+        let elapsed = tick_start.elapsed();
+        if elapsed < period {
+            Timer::after(period - elapsed).await;
+        }
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -68,29 +68,25 @@ pub async fn start_hmi(
                 .unwrap_or(false);
         drop(state);
 
-        let period_ms = period.as_millis().max(1) as u64;
-        let fast_pulse_ms = (period_ms / 4).max(1);
-        let fast_pulse = Duration::from_millis(fast_pulse_ms);
-        let fast_gap = fast_pulse;
-
         if gps_fix_recent {
             // GPS fix -> solid
             neopixel
                 .set_color_with_brightness(color, neopixel_brightness)
                 .await;
         } else if gps_rx_recent {
-            // GPS connected, no fix -> fast blink (double pulse)
+            // GPS connected, no fix -> fast double pulse (0.1s on, 0.1s off, 0.1s on, 0.7s off)
             neopixel
                 .set_color_with_brightness(color, neopixel_brightness)
                 .await;
-            Timer::after(fast_pulse).await;
+            Timer::after_millis(100).await;
             neopixel.clear().await;
-            Timer::after(fast_gap).await;
+            Timer::after_millis(100).await;
             neopixel
                 .set_color_with_brightness(color, neopixel_brightness)
                 .await;
-            Timer::after(fast_pulse).await;
+            Timer::after_millis(100).await;
             neopixel.clear().await;
+            Timer::after_millis(700).await;
         } else {
             // No GPS data -> slow blink
             slow_blink_on = !slow_blink_on;

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/state.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/state.rs
@@ -6,6 +6,7 @@ pub struct HmiStateData {
     pub last_imu_timestamp: Option<Instant>,
     pub gps_fix: bool,
     pub last_gps_timestamp: Option<Instant>,
+    pub last_gps_rx_timestamp: Option<Instant>,
 }
 
 impl Default for HmiStateData {
@@ -14,6 +15,7 @@ impl Default for HmiStateData {
             last_imu_timestamp: None,
             gps_fix: false,
             last_gps_timestamp: None,
+            last_gps_rx_timestamp: None,
         }
     }
 }
@@ -26,6 +28,7 @@ impl HmiState {
             last_imu_timestamp: None,
             gps_fix: false,
             last_gps_timestamp: None,
+            last_gps_rx_timestamp: None,
         }))
     }
 }


### PR DESCRIPTION
# Two Changes
1. Change the gps high baud rate command such that the baud rate config becomes permanent, not temporary. (High baudrate 460800, default baudrate 38400)
2. Update the gps light pattern so we understand more of gps status
- Old pattern:
    - Slow Blinking ==> waiting for fix
    - SOlid  ==> fix acquired
- New pattern:
    - Slow Blinking ==> No GPS/UART connection
    - Quick Double-Pulse (0.1s on, 0.1s off, 0.1s on, 0.7s off) ==> There is GPS connection, waiting for fix/There is GPS connection, can't understand the message
    - Solid ==> GPS fix acquired