### PR TITLE
Added Node ID in Heartbeat Message

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
@@ -35,31 +35,35 @@ impl MessageType {
 
 /// Heartbeat message data structure
 ///
-/// Contains a magic byte for validation. Timestamp is at the SensorMessage level.
+/// Contains a magic byte for validation and the node's full identifier.
+/// Timestamp is at the SensorMessage level.
 #[derive(Debug, Clone, Copy)]
 pub struct HeartbeatData {
     /// Magic byte for validation (typically 0x42 or custom value)
     pub magic: u8,
+    /// Node identifier (position + instance)
+    pub node_id: crate::types::NodeId,
 }
 
 impl HeartbeatData {
     /// Size in bytes when serialized
-    pub const SERIALIZED_SIZE: usize = 1; // magic only
+    pub const SERIALIZED_SIZE: usize = 3; // magic(1) + position(1) + instance(1)
 
     /// Default magic byte value
     pub const DEFAULT_MAGIC: u8 = 0x42;
 
-    /// Create a new heartbeat with magic byte
+    /// Create a new heartbeat with magic byte and node ID
     ///
     /// # Arguments
     /// * `magic` - Magic byte for validation
-    pub fn new(magic: u8) -> Self {
-        Self { magic }
+    /// * `node_id` - Node identifier (position + instance)
+    pub fn new(magic: u8, node_id: crate::types::NodeId) -> Self {
+        Self { magic, node_id }
     }
 
-    /// Create a new heartbeat with default magic byte
+    /// Create a new heartbeat with default magic byte and default node ID
     pub fn default() -> Self {
-        Self::new(Self::DEFAULT_MAGIC)
+        Self::new(Self::DEFAULT_MAGIC, crate::types::NodeId::default())
     }
 }
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -18,7 +18,7 @@ pub const HEADER_SIZE: usize = 1 + 8; // message_type(1) + timestamp_us(8) = 9 b
 
 /// Serialize heartbeat data into a byte buffer
 ///
-/// Format: [MessageType:1][Timestamp:8][Magic:1]
+/// Format: [MessageType:1][Timestamp:8][Magic:1][Position:1][Instance:1]
 ///
 /// # Arguments
 /// * `timestamp_us` - Sender's timestamp in microseconds
@@ -49,6 +49,13 @@ pub fn serialize_heartbeat(
 
     // Write magic byte
     buffer[offset] = data.magic;
+    offset += 1;
+
+    // Write node ID (position + instance)
+    let node_id_bytes = data.node_id.to_bytes();
+    buffer[offset] = node_id_bytes[0]; // position
+    offset += 1;
+    buffer[offset] = node_id_bytes[1]; // instance
     offset += 1;
 
     Ok(offset)
@@ -316,5 +323,13 @@ fn deserialize_heartbeat(data: &[u8], payload_offset: usize) -> Result<SensorPay
     }
 
     let magic = data[payload_offset];
-    Ok(SensorPayload::Heartbeat(HeartbeatData { magic }))
+    
+    // Read NodeId (position + instance)
+    let node_id_bytes = [
+        data[payload_offset + 1], // position
+        data[payload_offset + 2], // instance
+    ];
+    let node_id = crate::types::NodeId::from_bytes(node_id_bytes);
+    
+    Ok(SensorPayload::Heartbeat(HeartbeatData { magic, node_id }))
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -455,10 +455,16 @@ async fn espnow_bridge_task(
     _wifi_controller: esp_radio::wifi::WifiController<'static>,
     mut usb_serial: UsbSerial,
 ) {
+    use heapless::index_map::FnvIndexMap;
+    use crate::types::CarPosition;
+
     info!("[BRIDGE] Bridge task started (ESP-NOW -> USB)");
 
     // Buffer for serializing messages
     let mut msg_buffer = [0u8; MAX_USB_MESSAGE_SIZE];
+
+    // MAC address to NodeId mapping (supports up to 16 sensor nodes)
+    let mut mac_to_node_id: FnvIndexMap<[u8; 6], NodeId, 16> = FnvIndexMap::new();
 
     // Statistics
     let mut messages_forwarded: u32 = 0;
@@ -471,9 +477,42 @@ async fn espnow_bridge_task(
                 let src_mac: [u8; 6] = msg.src_address;
                 let timestamp_us = msg.timestamp_us;
 
-                // For now, use a default NodeId - in production this would be
-                // looked up from a MAC -> NodeId mapping table
-                let node_id = NodeId::default();
+                // Update MAC -> NodeId mapping if this is a heartbeat
+                if let SensorPayload::Heartbeat(heartbeat_data) = &msg.payload {
+                    let new_node_id = heartbeat_data.node_id;
+                    
+                    // Check if this is a new node or NodeId changed
+                    let node_id_updated = match mac_to_node_id.get(&src_mac) {
+                        Some(old_id) if *old_id != new_node_id => true,
+                        None => true,
+                        _ => false,
+                    };
+
+                    if node_id_updated {
+                        match mac_to_node_id.insert(src_mac, new_node_id) {
+                            Ok(_) => {
+                                info!(
+                                    "[BRIDGE] Updated node mapping: {} -> {}:{}",
+                                    format_mac(&src_mac),
+                                    new_node_id.position.as_str(),
+                                    new_node_id.instance
+                                );
+                            }
+                            Err(_) => {
+                                warn!(
+                                    "[BRIDGE] Failed to store node ID for {} (map full)",
+                                    format_mac(&src_mac)
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // Look up NodeId for this MAC, default to Custom:0 if not found
+                let node_id = mac_to_node_id
+                    .get(&src_mac)
+                    .copied()
+                    .unwrap_or_else(|| NodeId::new(CarPosition::Custom, 0));
 
                 // Serialize the message
                 match serialize_forwarded_message(
@@ -489,9 +528,11 @@ async fn espnow_bridge_task(
                             Ok(()) => {
                                 messages_forwarded += 1;
                                 trace!(
-                                    "[BRIDGE] Forwarded {:?} from {} (total: {})",
+                                    "[BRIDGE] Forwarded {:?} from {} ({}:{}) (total: {})",
                                     msg.payload.message_type(),
                                     format_mac(&src_mac),
+                                    node_id.position.as_str(),
+                                    node_id.instance,
                                     messages_forwarded
                                 );
                             }
@@ -555,8 +596,12 @@ fn handle_received_message(msg: &SensorMessage) {
     match &msg.payload {
         SensorPayload::Heartbeat(data) => {
             info!(
-                "[ESP-NOW RX] Heartbeat from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | magic=0x{:02X}, time={}us",
-                src[0], src[1], src[2], src[3], src[4], src[5], data.magic, timestamp
+                "[ESP-NOW RX] Heartbeat from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | node={}:{}, magic=0x{:02X}, time={}us",
+                src[0], src[1], src[2], src[3], src[4], src[5], 
+                data.node_id.position.as_str(),
+                data.node_id.instance,
+                data.magic, 
+                timestamp
             );
         }
         SensorPayload::Imu(data) => {

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -459,12 +459,16 @@ async fn espnow_bridge_task(
     use crate::types::CarPosition;
 
     info!("[BRIDGE] Bridge task started (ESP-NOW -> USB)");
+    info!("[BRIDGE] Auto-assigning instance numbers based on MAC discovery order");
 
     // Buffer for serializing messages
     let mut msg_buffer = [0u8; MAX_USB_MESSAGE_SIZE];
 
     // MAC address to NodeId mapping (supports up to 16 sensor nodes)
     let mut mac_to_node_id: FnvIndexMap<[u8; 6], NodeId, 16> = FnvIndexMap::new();
+    
+    // Track next available instance number for each position
+    let mut next_instance_per_position: FnvIndexMap<CarPosition, u8, 16> = FnvIndexMap::new();
 
     // Statistics
     let mut messages_forwarded: u32 = 0;
@@ -477,26 +481,28 @@ async fn espnow_bridge_task(
                 let src_mac: [u8; 6] = msg.src_address;
                 let timestamp_us = msg.timestamp_us;
 
-                // Update MAC -> NodeId mapping if this is a heartbeat
+                // Auto-assign instance numbers based on MAC discovery order
                 if let SensorPayload::Heartbeat(heartbeat_data) = &msg.payload {
-                    let new_node_id = heartbeat_data.node_id;
+                    let position = heartbeat_data.node_id.position;
                     
-                    // Check if this is a new node or NodeId changed
-                    let node_id_updated = match mac_to_node_id.get(&src_mac) {
-                        Some(old_id) if *old_id != new_node_id => true,
-                        None => true,
-                        _ => false,
-                    };
-
-                    if node_id_updated {
-                        match mac_to_node_id.insert(src_mac, new_node_id) {
+                    // Check if this MAC has been seen before
+                    if !mac_to_node_id.contains_key(&src_mac) {
+                        // New MAC discovered - assign next available instance for this position
+                        let instance = *next_instance_per_position.get(&position).unwrap_or(&0);
+                        let assigned_node_id = NodeId::new(position, instance);
+                        
+                        // Store the assignment
+                        match mac_to_node_id.insert(src_mac, assigned_node_id) {
                             Ok(_) => {
                                 info!(
-                                    "[BRIDGE] Updated node mapping: {} -> {}:{}",
+                                    "[BRIDGE] New node discovered: {} -> {}:{} (auto-assigned)",
                                     format_mac(&src_mac),
-                                    new_node_id.position.as_str(),
-                                    new_node_id.instance
+                                    position.as_str(),
+                                    instance
                                 );
+                                
+                                // Increment instance counter for this position
+                                let _ = next_instance_per_position.insert(position, instance + 1);
                             }
                             Err(_) => {
                                 warn!(
@@ -504,6 +510,30 @@ async fn espnow_bridge_task(
                                     format_mac(&src_mac)
                                 );
                             }
+                        }
+                    } else {
+                        // MAC already known - check if position changed
+                        let stored_node_id = *mac_to_node_id.get(&src_mac).unwrap(); // Copy the value
+                        if stored_node_id.position != position {
+                            // Position changed - assign new instance for new position
+                            let instance = *next_instance_per_position.get(&position).unwrap_or(&0);
+                            let new_node_id = NodeId::new(position, instance);
+                            
+                            // Copy old values before mutation
+                            let old_position = stored_node_id.position;
+                            let old_instance = stored_node_id.instance;
+                            
+                            let _ = mac_to_node_id.insert(src_mac, new_node_id);
+                            let _ = next_instance_per_position.insert(position, instance + 1);
+                            
+                            info!(
+                                "[BRIDGE] Node position changed: {} -> {}:{} (was {}:{})",
+                                format_mac(&src_mac),
+                                position.as_str(),
+                                instance,
+                                old_position.as_str(),
+                                old_instance
+                            );
                         }
                     }
                 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -494,12 +494,12 @@ async fn espnow_bridge_task(
                         // Store the assignment
                         match mac_to_node_id.insert(src_mac, assigned_node_id) {
                             Ok(_) => {
-                                info!(
-                                    "[BRIDGE] New node discovered: {} -> {}:{} (auto-assigned)",
-                                    format_mac(&src_mac),
-                                    position.as_str(),
-                                    instance
-                                );
+                                // info!(
+                                //     "[BRIDGE] New node discovered: {} -> {}:{} (auto-assigned)",
+                                //     format_mac(&src_mac),
+                                //     position.as_str(),
+                                //     instance
+                                // );
                                 
                                 // Increment instance counter for this position
                                 let _ = next_instance_per_position.insert(position, instance + 1);

--- a/sw/sensor_board/sensor_board_rev1_test/src/types.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/types.rs
@@ -6,7 +6,7 @@
 // =============================================================================
 
 /// Position where sensor node is installed on the car
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum CarPosition {
     FrontLeft = 0,


### PR DESCRIPTION
# Brief
The heartbeat message used to be pretty useless. We did not forward the heartbeat message or use it for anything.\
But things start to change in this PR.

- Node ID, containing the car position and instance number, is now part of the heartbeat message
- Bridge board has a heapless map that maps the MAC address with the Node ID; forwarded message will have the node id information
- If there are two nodes placed at the same car position, then the bridge board would automatically resolve it and assign the second node with a higher instance number (first node: position = center, instance = 0; second node: position = center, instance = 1).

# Pic
<img width="780" height="59" alt="image" src="https://github.com/user-attachments/assets/d107c0b3-0c54-45f2-8fe7-717410bc8d5d" />
