### PR TITLE
associating video/image recording with switch io26

### DIFF
--- a/sw/tools/rpi_rx_rust/README.md
+++ b/sw/tools/rpi_rx_rust/README.md
@@ -9,7 +9,7 @@ Raspberry Pi receiver for the sensor_board COBS-over-serial stream. Decodes IMU,
 - **Real-time AHRS** (optional): Madgwick orientation filter plus velocity/position integration in NED. Uses the first IMU node as primary; first 10 seconds are treated as “at rest” for gyro bias and velocity zeroing. Outputs synthesized lat/lon/alt, vehicle heading, ground track, roll/pitch/yaw, and NED velocity at a fixed rate (default 10 Hz).
 - **Post-process AHRS**: The `ahrs_postprocess` binary runs AHRS on an existing raw log CSV (e.g. for re-runs with different parameters or when real-time AHRS was not used).
 - **Unified log layout**: All binaries write under `~/daq/logs/<date>/` with `<time>_raw.csv` and `<time>_postprocess.csv` (postprocess = AHRS output).
-- **GPIO-controlled service**: The `rpi_rx_rust_gpio` binary (Linux, `--features gpio`) uses two GPIOs to control logging with no CLI flags, suitable for a systemd service that starts on boot.
+- **GPIO-controlled service**: The `rpi_rx_rust_gpio` binary (Linux, `--features gpio`) uses GPIOs to control logging and video recording with no CLI flags, suitable for a systemd service that starts on boot.
 
 ## Binaries
 
@@ -48,8 +48,11 @@ Assumes the first 10 seconds of the log are at rest. Uses first GPS fix as origi
 
 - **GPIO #11 (BCM 11)**: Init — start raw logging and allow AHRS to initialize (vehicle assumed level and stationary).
 - **GPIO #19 (BCM 19)**: Postprocessed — when high, also log AHRS output at the default rate (10 Hz).
+- **GPIO #26 (BCM 26)**: Video recording — when high, start video recording via camera server; when low, stop recording.
 
-Logging runs while **either** GPIO is high. Logs **stop only when both GPIOs are low**. Temporary loss of serial data does not stop the session; only both GPIOs going low does.
+Data logging runs while **either** GPIO #11 or #19 is high. Logs **stop only when both GPIOs are low**. Temporary loss of serial data does not stop the session; only both GPIOs going low does.
+
+Video recording is controlled independently by GPIO #26. The service communicates with a camera server running on `localhost:8888` (e.g., the `record.py` server from `/home/hardy/daq/FYDP-CV-Piside/`).
 
 - **Build** (on Linux, with libgpiod):  
   `cargo build --release --features gpio`

--- a/sw/tools/rpi_rx_rust/rpi-rx-rust.service
+++ b/sw/tools/rpi_rx_rust/rpi-rx-rust.service
@@ -1,7 +1,9 @@
 [Unit]
-Description=RPi RX Rust Data Logger (GPIO Controlled)
+Description=RPi RX Rust Data Logger (GPIO Controlled with Video Recording)
 Documentation=https://github.com/your-org/vehicle-daq
 After=network.target
+# Note: This service controls video recording via GPIO 26.
+# Ensure the camera server (record.py) is running on port 8888.
 
 [Service]
 Type=simple
@@ -13,6 +15,9 @@ Group=hardy
 WorkingDirectory=/opt/rpi_rx_rust
 
 # No CLI flags: GPIO controls start/stop. Build with: cargo build --release --features gpio
+# GPIO 11: Start raw data logging
+# GPIO 5:  Start postprocessed AHRS logging
+# GPIO 26: Control video recording (high=start, low=stop via camera server on port 8888)
 ExecStart=/opt/rpi_rx_rust/bin/rpi_rx_rust_gpio
 
 # Logs go to ~/daq/logs/<date>/<time>_raw.csv and <time>_postprocess.csv (user's HOME when run as User=)

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
@@ -1,8 +1,9 @@
 //! GPIO-controlled logging service: no CLI, for systemd.
 //!
 //! GPIO #11: init (start raw logging, AHRS init, assume vehicle level stationary).
-//! GPIO #19:  start logging including postprocessed AHRS at default rate (10 Hz).
-//! Logs stop only when **both** GPIOs go LOW. Temporary data gaps do not stop logging.
+//! GPIO #19: start logging including postprocessed AHRS at default rate (10 Hz).
+//! GPIO #26: control video recording (high = start, low = stop).
+//! Logs stop only when **both** GPIOs #11 and #19 go LOW. Temporary data gaps do not stop logging.
 //!
 //! Build on Linux with: `cargo build --release --features gpio`
 
@@ -11,17 +12,21 @@ use csv::Writer;
 use gpiod::{Chip, EdgeDetect, Options, Bias};
 use log::*;
 use rpi_rx_rust::session::{run_session, ByteSource};
+use std::cell::Cell;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
 use std::path::PathBuf;
 use std::time::Duration;
 
 const GPIO_INIT: u32 = 11;   // BCM 11: init / raw
 const GPIO_POST: u32 = 19;   // BCM 19: postprocessed logging
+const GPIO_VIDEO: u32 = 26;  // BCM 26: video recording control
 const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM0";
 const DEFAULT_BAUD_RATE: u32 = 115_200;
 const SERIAL_READ_TIMEOUT_MS: u64 = 200;
 const DEFAULT_AHRS_HZ: u32 = 10;
+const CAMERA_SERVER_ADDR: &str = "127.0.0.1:8888";
 
 /// Byte source that reads one byte from serial with timeout; returns None on timeout.
 struct SerialTimeoutByteSource {
@@ -66,33 +71,76 @@ fn serial_port() -> String {
     std::env::var("RPI_RX_SERIAL_PORT").unwrap_or_else(|_| DEFAULT_SERIAL_PORT.to_string())
 }
 
+/// Send command to the camera server (record.py)
+fn send_camera_command(command: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let mut stream = TcpStream::connect(CAMERA_SERVER_ADDR)?;
+    stream.set_write_timeout(Some(Duration::from_secs(2)))?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    
+    stream.write_all(command.as_bytes())?;
+    stream.flush()?;
+    
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    
+    Ok(response.trim().to_string())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_default_env()
         .filter_level(log::LevelFilter::Info)
         .init();
 
-    info!("rpi_rx_rust_gpio: GPIO {} (init), GPIO {} (post); logs under ~/daq/logs/<date>/", GPIO_INIT, GPIO_POST);
+    info!("rpi_rx_rust_gpio: GPIO {} (init), GPIO {} (post), GPIO {} (video); logs under ~/daq/logs/<date>/", GPIO_INIT, GPIO_POST, GPIO_VIDEO);
 
     let chip = Chip::new("gpiochip0").or_else(|_| Chip::new(0))?;
-    let opts = Options::input([GPIO_INIT, GPIO_POST])
+    let opts = Options::input([GPIO_INIT, GPIO_POST, GPIO_VIDEO])
         .edge(EdgeDetect::Both)
         .bias(Bias::PullDown)
         .consumer("rpi_rx_rust_gpio");
     let mut inputs = chip.request_lines(opts)?;
-    info!("GPIO {} and {} requested (edge both, pull-down enabled)", GPIO_INIT, GPIO_POST);
+    info!("GPIO {}, {}, and {} requested (edge both, pull-down enabled)", GPIO_INIT, GPIO_POST, GPIO_VIDEO);
     
     // Check initial state
-    let initial_values: [bool; 2] = inputs.get_values([false, false])?;
-    info!("Initial GPIO state: GPIO{}={}, GPIO{}={}", 
-          GPIO_INIT, initial_values[0], GPIO_POST, initial_values[1]);
+    let initial_values: [bool; 3] = inputs.get_values([false, false, false])?;
+    info!("Initial GPIO state: GPIO{}={}, GPIO{}={}, GPIO{}={}", 
+          GPIO_INIT, initial_values[0], GPIO_POST, initial_values[1], GPIO_VIDEO, initial_values[2]);
+    
+    // Track video recording state (using Cell for interior mutability in closure)
+    let video_recording = Cell::new(false);
 
     loop {
-        // Idle: wait for an edge, then check if either GPIO is high
+        // Idle: wait for an edge, then check GPIO states
         let _event = inputs.read_event()?;
-        let values: [bool; 2] = inputs.get_values([false, false])?;
+        let values: [bool; 3] = inputs.get_values([false, false, false])?;
         let gpio11_high = values[0];
         let gpio19_high = values[1];
-        info!("GPIO edge detected: GPIO{}={}, GPIO{}={}", GPIO_INIT, gpio11_high, GPIO_POST, gpio19_high);
+        let gpio26_high = values[2];
+        info!("GPIO edge detected: GPIO{}={}, GPIO{}={}, GPIO{}={}", 
+              GPIO_INIT, gpio11_high, GPIO_POST, gpio19_high, GPIO_VIDEO, gpio26_high);
+        
+        // Handle video recording control (GPIO 26)
+        if gpio26_high && !video_recording.get() {
+            info!("GPIO {} high: starting video recording", GPIO_VIDEO);
+            match send_camera_command("start") {
+                Ok(response) => {
+                    info!("Camera server response: {}", response);
+                    video_recording.set(true);
+                }
+                Err(e) => error!("Failed to start video recording: {}", e),
+            }
+        } else if !gpio26_high && video_recording.get() {
+            info!("GPIO {} low: stopping video recording", GPIO_VIDEO);
+            match send_camera_command("stop") {
+                Ok(response) => {
+                    info!("Camera server response: {}", response);
+                    video_recording.set(false);
+                }
+                Err(e) => error!("Failed to stop video recording: {}", e),
+            }
+        }
+        
+        // Check if data logging should be active (GPIO 11 or 19)
         let active = gpio11_high || gpio19_high;
         if !active {
             info!("Both GPIOs low, staying idle");
@@ -134,11 +182,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let mut byte_source = SerialTimeoutByteSource::new(port);
         let mut should_stop = || {
-            let values: [bool; 2] = match inputs.get_values([false, false]) {
+            let values: [bool; 3] = match inputs.get_values([false, false, false]) {
                 Ok(v) => v,
                 Err(_) => return true,
             };
-            let active = values[0] || values[1];
+            let gpio11 = values[0];
+            let gpio19 = values[1];
+            let gpio26 = values[2];
+            
+            // Handle video recording control (check periodically during session)
+            if gpio26 && !video_recording.get() {
+                info!("GPIO {} high: starting video recording (during session)", GPIO_VIDEO);
+                if let Ok(response) = send_camera_command("start") {
+                    info!("Camera server response: {}", response);
+                    video_recording.set(true);
+                }
+            } else if !gpio26 && video_recording.get() {
+                info!("GPIO {} low: stopping video recording (during session)", GPIO_VIDEO);
+                if let Ok(response) = send_camera_command("stop") {
+                    info!("Camera server response: {}", response);
+                    video_recording.set(false);
+                }
+            }
+            
+            let active = gpio11 || gpio19;
             !active
         };
 


### PR DESCRIPTION
As the commit message suggested. Turn on Switch io26 will send a start recording socket message to the video system server, thus start running the python server script. Turn off Switch will send a stop recording socket message.