### PR TITLE
Hardy/time sync firmware

### DIFF
--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
@@ -14,6 +14,8 @@ pub enum MessageType {
     Imu = 0x01,
     /// GPS sensor data
     Gps = 0x02,
+    /// Time synchronization from bridge/RPi
+    TimeSync = 0xFE,
     /// Heartbeat/keep-alive message
     Heartbeat = 0xFF,
 }
@@ -23,6 +25,7 @@ impl MessageType {
         match value {
             0x01 => Some(MessageType::Imu),
             0x02 => Some(MessageType::Gps),
+            0xFE => Some(MessageType::TimeSync),
             0xFF => Some(MessageType::Heartbeat),
             _ => None,
         }
@@ -67,6 +70,24 @@ impl HeartbeatData {
     }
 }
 
+/// Time synchronization data from RPi (via bridge) to all nodes.
+///
+/// Contains the session-elapsed time from the RPi time master.
+/// Nodes use this to compute their local offset for synchronized timestamps.
+#[derive(Debug, Clone, Copy)]
+pub struct TimeSyncData {
+    /// Session elapsed time in microseconds (from RPi monotonic clock)
+    pub session_time_us: u64,
+}
+
+impl TimeSyncData {
+    pub const SERIALIZED_SIZE: usize = 8; // session_time_us(8)
+
+    pub fn new(session_time_us: u64) -> Self {
+        Self { session_time_us }
+    }
+}
+
 // Serialization sizes for aircomm protocol (payload only, excluding header)
 // Header is always: message_type(1) + timestamp(8) = 9 bytes
 // HeartbeatData: magic(1) = 1 byte (timestamp moved to message level)
@@ -96,6 +117,7 @@ pub enum SensorPayload {
     Imu(ImuData),
     Gps(GpsData),
     Heartbeat(HeartbeatData),
+    TimeSync(TimeSyncData),
 }
 
 impl SensorPayload {
@@ -104,6 +126,7 @@ impl SensorPayload {
             SensorPayload::Imu(_) => MessageType::Imu,
             SensorPayload::Gps(_) => MessageType::Gps,
             SensorPayload::Heartbeat(_) => MessageType::Heartbeat,
+            SensorPayload::TimeSync(_) => MessageType::TimeSync,
         }
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
@@ -13,7 +13,9 @@ pub mod message;
 pub mod protocol;
 
 pub use error::{AirCommError, Result};
-pub use message::{GpsData, HeartbeatData, ImuData, MessageType, SensorMessage, SensorPayload};
+pub use message::{
+    GpsData, HeartbeatData, ImuData, MessageType, SensorMessage, SensorPayload, TimeSyncData,
+};
 pub use sender::BROADCAST;
 
 use esp_radio::esp_now::{EspNow, EspNowWifiInterface, PeerInfo};
@@ -60,6 +62,16 @@ impl<'a> AirCommTransceiver<'a> {
         peer_addr: &[u8; 6],
     ) -> Result<()> {
         sender::send_gps(&mut self.esp_now, timestamp_us, data, peer_addr).await
+    }
+
+    /// Broadcast time sync data to all peers (bridge -> data nodes)
+    pub async fn send_timesync(
+        &mut self,
+        timestamp_us: u64,
+        data: &TimeSyncData,
+        peer_addr: &[u8; 6],
+    ) -> Result<()> {
+        sender::send_timesync(&mut self.esp_now, timestamp_us, data, peer_addr).await
     }
 
     /// Receive sensor data (suspends until data arrives)

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -179,6 +179,41 @@ pub fn serialize_gps(timestamp_us: u64, data: &GpsData, buffer: &mut [u8]) -> Re
     Ok(offset)
 }
 
+/// Serialize time sync data into a byte buffer
+///
+/// Format: [MessageType:1][Timestamp:8][session_time_us:8]
+///
+/// # Arguments
+/// * `timestamp_us` - Sender's local timestamp in microseconds
+/// * `data` - Time sync data containing the RPi session elapsed time
+/// * `buffer` - Output buffer (must be at least HEADER_SIZE + TimeSyncData::SERIALIZED_SIZE)
+///
+/// # Returns
+/// Number of bytes written
+pub fn serialize_timesync(
+    timestamp_us: u64,
+    data: &TimeSyncData,
+    buffer: &mut [u8],
+) -> Result<usize> {
+    let required_size = HEADER_SIZE + TimeSyncData::SERIALIZED_SIZE;
+    if buffer.len() < required_size {
+        return Err(AirCommError::BufferTooSmall);
+    }
+
+    let mut offset = 0;
+
+    buffer[offset] = MessageType::TimeSync.to_u8();
+    offset += 1;
+
+    LittleEndian::write_u64(&mut buffer[offset..], timestamp_us);
+    offset += 8;
+
+    LittleEndian::write_u64(&mut buffer[offset..], data.session_time_us);
+    offset += 8;
+
+    Ok(offset)
+}
+
 /// Deserialize received data into a sensor message
 ///
 /// Reads the message type header, timestamp, and deserializes the appropriate payload
@@ -204,6 +239,7 @@ pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
         MessageType::Imu => deserialize_imu(data, payload_offset)?,
         MessageType::Gps => deserialize_gps(data, payload_offset)?,
         MessageType::Heartbeat => deserialize_heartbeat(data, payload_offset)?,
+        MessageType::TimeSync => deserialize_timesync(data, payload_offset)?,
     };
 
     Ok(SensorMessage {
@@ -332,4 +368,16 @@ fn deserialize_heartbeat(data: &[u8], payload_offset: usize) -> Result<SensorPay
     let node_id = crate::types::NodeId::from_bytes(node_id_bytes);
     
     Ok(SensorPayload::Heartbeat(HeartbeatData { magic, node_id }))
+}
+
+/// Deserialize TimeSync payload from buffer
+fn deserialize_timesync(data: &[u8], payload_offset: usize) -> Result<SensorPayload> {
+    let required_size = HEADER_SIZE + TimeSyncData::SERIALIZED_SIZE;
+    if data.len() < required_size {
+        return Err(AirCommError::InvalidMessage);
+    }
+
+    let session_time_us = LittleEndian::read_u64(&data[payload_offset..]);
+
+    Ok(SensorPayload::TimeSync(TimeSyncData { session_time_us }))
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
@@ -5,7 +5,9 @@
 
 use super::error::Result;
 use super::message::*;
-use super::protocol::{MAX_PAYLOAD_SIZE, serialize_gps, serialize_heartbeat, serialize_imu};
+use super::protocol::{
+    MAX_PAYLOAD_SIZE, serialize_gps, serialize_heartbeat, serialize_imu, serialize_timesync,
+};
 use esp_radio::esp_now::EspNow;
 
 /// Broadcast MAC address for sending to all peers
@@ -50,6 +52,21 @@ pub(crate) async fn send_gps(
 ) -> Result<()> {
     let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
     let size = serialize_gps(timestamp_us, data, &mut buffer)?;
+
+    esp_now.send_async(peer_addr, &buffer[..size]).await?;
+
+    Ok(())
+}
+
+/// Send time sync data asynchronously (bridge -> data nodes)
+pub(crate) async fn send_timesync(
+    esp_now: &mut EspNow<'_>,
+    timestamp_us: u64,
+    data: &TimeSyncData,
+    peer_addr: &[u8; 6],
+) -> Result<()> {
+    let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
+    let size = serialize_timesync(timestamp_us, data, &mut buffer)?;
 
     esp_now.send_async(peer_addr, &buffer[..size]).await?;
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -19,6 +19,8 @@ use crate::EspNowMode;
 use crate::SharedSpiDevice;
 #[cfg(feature = "wifi")]
 use crate::aircomm::{AirCommTransceiver, BROADCAST, HeartbeatData, SensorMessage, SensorPayload};
+#[cfg(all(feature = "wifi", feature = "usb"))]
+use crate::aircomm::TimeSyncData;
 #[cfg(feature = "gps")]
 use crate::gps::{init_gps, start_gps};
 #[cfg(feature = "hmi")]
@@ -29,8 +31,8 @@ use crate::imu::start_imu;
 use crate::types::NodeId;
 #[cfg(feature = "usb")]
 use crate::usb::{
-    MAX_USB_MESSAGE_SIZE, UsbError, UsbSerial, format_mac, serialize_forwarded_message,
-    wait_for_usb_host_timeout,
+    MAX_USB_MESSAGE_SIZE, UsbCommand, UsbError, UsbSerial, UsbSerialRx, format_mac,
+    serialize_forwarded_message,
 };
 
 /// Capacity of the sensor data channel
@@ -145,6 +147,9 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
                             info!("ESP-NOW mode: Bridge (receive + forward to USB)");
                             if let Some(usb_tx) = board.take_usb_serial_tx() {
                                 let usb_serial = UsbSerial::new(usb_tx);
+                                let usb_rx = board
+                                    .take_usb_serial_rx()
+                                    .map(UsbSerialRx::new);
                                 info!("[BRIDGE] Waiting for USB host before starting");
                                 // Wait for USB host with neopixel animation for visual feedback
                                 {
@@ -200,6 +205,7 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
                                         transceiver,
                                         wifi.controller,
                                         usb_serial,
+                                        usb_rx,
                                     ))
                                     .expect("ESP-NOW bridge task did not spawn");
                             } else {
@@ -310,7 +316,7 @@ async fn start_gps_task(mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Asy
 /// ESP-NOW transceiver task
 ///
 /// Handles both receiving ESP-NOW messages and sending periodic heartbeats.
-/// Used by bridge/receiver nodes (e.g., DevKit-C) for testing or forwarding data.
+/// Applies TimeSync when received from bridge.
 ///
 /// Note: `_wifi_controller` must be kept alive for ESP-NOW to function properly.
 #[cfg(feature = "wifi")]
@@ -319,7 +325,7 @@ async fn espnow_transceiver_task(
     mut transceiver: AirCommTransceiver<'static>,
     _wifi_controller: esp_radio::wifi::WifiController<'static>,
 ) {
-    info!("[ESP-NOW] Transceiver task started (RX + TX heartbeats)");
+    info!("[ESP-NOW] Transceiver task started (RX + TX heartbeats, TimeSync)");
 
     const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -336,19 +342,22 @@ async fn espnow_transceiver_task(
             HEARTBEAT_INTERVAL - elapsed
         };
 
-        // Try to receive with timeout
         match embassy_time::with_timeout(timeout, transceiver.receive()).await {
             Ok(Ok(msg)) => {
-                // Successfully received a message
-                handle_received_message(&msg);
+                if let SensorPayload::TimeSync(ts_data) = &msg.payload {
+                    crate::timebase::apply_sync(ts_data.session_time_us);
+                    info!(
+                        "[ESP-NOW RX] TimeSync applied: session={}us",
+                        ts_data.session_time_us
+                    );
+                } else {
+                    handle_received_message(&msg);
+                }
             }
             Ok(Err(e)) => {
-                // Receive error
                 warn!("[ESP-NOW RX] Error: {:?}", e);
             }
-            Err(_) => {
-                // Timeout - no message received, that's fine
-            }
+            Err(_) => {}
         }
 
         // Check if it's time to send heartbeat
@@ -362,7 +371,7 @@ async fn espnow_transceiver_task(
 /// ESP-NOW sender task (default)
 ///
 /// Receives sensor data from the channel and transmits via ESP-NOW.
-/// Also sends periodic heartbeats to indicate the node is alive.
+/// Also sends periodic heartbeats and polls for incoming TimeSync messages.
 ///
 /// Note: `_wifi_controller` must be kept alive for ESP-NOW to function properly.
 #[cfg(feature = "wifi")]
@@ -371,9 +380,10 @@ async fn espnow_sender_task(
     mut transceiver: AirCommTransceiver<'static>,
     _wifi_controller: esp_radio::wifi::WifiController<'static>,
 ) {
-    info!("[ESP-NOW] Sender task started");
+    info!("[ESP-NOW] Sender task started (with TimeSync RX)");
 
     const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+    const TIMESYNC_RX_POLL: Duration = Duration::from_millis(1);
 
     // Send first heartbeat immediately
     send_heartbeat(&mut transceiver).await;
@@ -391,8 +401,7 @@ async fn espnow_sender_task(
         // Try to receive sensor data from channel with timeout
         match embassy_time::with_timeout(timeout, SENSOR_CHANNEL.receive()).await {
             Ok(payload) => {
-                // Got sensor data, transmit it
-                let timestamp_us = Instant::now().as_micros();
+                let timestamp_us = crate::timebase::synced_timestamp_us();
 
                 let result = match &payload {
                     SensorPayload::Imu(data) => {
@@ -415,6 +424,10 @@ async fn espnow_sender_task(
                             .send_heartbeat(timestamp_us, data, &BROADCAST)
                             .await
                     }
+                    SensorPayload::TimeSync(_) => {
+                        // TimeSync payloads are not sent from data nodes
+                        Ok(())
+                    }
                 };
 
                 match result {
@@ -431,7 +444,26 @@ async fn espnow_sender_task(
             }
         }
 
-        // Check if it's time to send heartbeat
+        // Poll for incoming ESP-NOW TimeSync from bridge (very short timeout)
+        match embassy_time::with_timeout(TIMESYNC_RX_POLL, transceiver.receive()).await {
+            Ok(Ok(msg)) => {
+                if let SensorPayload::TimeSync(ts_data) = &msg.payload {
+                    crate::timebase::apply_sync(ts_data.session_time_us);
+                    info!(
+                        "[ESP-NOW RX] TimeSync applied: session={}us",
+                        ts_data.session_time_us
+                    );
+                }
+                // Other message types received here are from other nodes; ignore
+            }
+            Ok(Err(e)) => {
+                warn!("[ESP-NOW RX] Error during TimeSync poll: {:?}", e);
+            }
+            Err(_) => {
+                // No incoming message -- expected
+            }
+        }
+
         if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
             send_heartbeat(&mut transceiver).await;
             last_heartbeat = Instant::now();
@@ -454,55 +486,70 @@ async fn espnow_bridge_task(
     mut transceiver: AirCommTransceiver<'static>,
     _wifi_controller: esp_radio::wifi::WifiController<'static>,
     mut usb_serial: UsbSerial,
+    mut usb_rx: Option<UsbSerialRx>,
 ) {
     use heapless::index_map::FnvIndexMap;
     use crate::types::CarPosition;
 
-    info!("[BRIDGE] Bridge task started (ESP-NOW -> USB)");
+    info!("[BRIDGE] Bridge task started (ESP-NOW <-> USB, TimeSync enabled)");
     info!("[BRIDGE] Auto-assigning instance numbers based on MAC discovery order");
 
-    // Buffer for serializing messages
-    let mut msg_buffer = [0u8; MAX_USB_MESSAGE_SIZE];
+    const ESPNOW_RX_TIMEOUT: Duration = Duration::from_millis(50);
 
-    // MAC address to NodeId mapping (supports up to 16 sensor nodes)
+    let mut msg_buffer = [0u8; MAX_USB_MESSAGE_SIZE];
     let mut mac_to_node_id: FnvIndexMap<[u8; 6], NodeId, 16> = FnvIndexMap::new();
-    
-    // Track next available instance number for each position
     let mut next_instance_per_position: FnvIndexMap<CarPosition, u8, 16> = FnvIndexMap::new();
 
-    // Statistics
     let mut messages_forwarded: u32 = 0;
     let mut errors: u32 = 0;
+    let mut timesync_count: u32 = 0;
 
     loop {
-        // Wait for incoming ESP-NOW message
-        match transceiver.receive().await {
-            Ok(msg) => {
+        // --- Poll USB RX for commands from RPi (non-blocking) ---
+        if let Some(ref mut rx) = usb_rx {
+            while let Some(cmd) = rx.poll_command() {
+                match cmd {
+                    UsbCommand::TimeSync { session_time_us } => {
+                        timesync_count += 1;
+                        crate::timebase::apply_sync(session_time_us);
+
+                        // Broadcast TimeSync to all data nodes
+                        let ts = crate::timebase::synced_timestamp_us();
+                        let data = TimeSyncData::new(session_time_us);
+                        if let Err(e) = transceiver.send_timesync(ts, &data, &BROADCAST).await {
+                            warn!("[BRIDGE] TimeSync broadcast failed: {:?}", e);
+                        } else {
+                            info!(
+                                "[BRIDGE] TimeSync #{}: session={}us, broadcast OK",
+                                timesync_count, session_time_us
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Receive ESP-NOW with timeout so we regularly poll USB RX ---
+        match embassy_time::with_timeout(ESPNOW_RX_TIMEOUT, transceiver.receive()).await {
+            Ok(Ok(msg)) => {
                 let src_mac: [u8; 6] = msg.src_address;
-                let timestamp_us = msg.timestamp_us;
+
+                // Use synced bridge-receive timestamp for forwarded messages
+                let timestamp_us = crate::timebase::synced_timestamp_us();
 
                 // Auto-assign instance numbers based on MAC discovery order
                 if let SensorPayload::Heartbeat(heartbeat_data) = &msg.payload {
                     let position = heartbeat_data.node_id.position;
-                    
-                    // Check if this MAC has been seen before
+
                     if !mac_to_node_id.contains_key(&src_mac) {
-                        // New MAC discovered - assign next available instance for this position
-                        let instance = *next_instance_per_position.get(&position).unwrap_or(&0);
+                        let instance =
+                            *next_instance_per_position.get(&position).unwrap_or(&0);
                         let assigned_node_id = NodeId::new(position, instance);
-                        
-                        // Store the assignment
+
                         match mac_to_node_id.insert(src_mac, assigned_node_id) {
                             Ok(_) => {
-                                // info!(
-                                //     "[BRIDGE] New node discovered: {} -> {}:{} (auto-assigned)",
-                                //     format_mac(&src_mac),
-                                //     position.as_str(),
-                                //     instance
-                                // );
-                                
-                                // Increment instance counter for this position
-                                let _ = next_instance_per_position.insert(position, instance + 1);
+                                let _ = next_instance_per_position
+                                    .insert(position, instance + 1);
                             }
                             Err(_) => {
                                 warn!(
@@ -512,20 +559,19 @@ async fn espnow_bridge_task(
                             }
                         }
                     } else {
-                        // MAC already known - check if position changed
-                        let stored_node_id = *mac_to_node_id.get(&src_mac).unwrap(); // Copy the value
+                        let stored_node_id = *mac_to_node_id.get(&src_mac).unwrap();
                         if stored_node_id.position != position {
-                            // Position changed - assign new instance for new position
-                            let instance = *next_instance_per_position.get(&position).unwrap_or(&0);
+                            let instance =
+                                *next_instance_per_position.get(&position).unwrap_or(&0);
                             let new_node_id = NodeId::new(position, instance);
-                            
-                            // Copy old values before mutation
+
                             let old_position = stored_node_id.position;
                             let old_instance = stored_node_id.instance;
-                            
+
                             let _ = mac_to_node_id.insert(src_mac, new_node_id);
-                            let _ = next_instance_per_position.insert(position, instance + 1);
-                            
+                            let _ =
+                                next_instance_per_position.insert(position, instance + 1);
+
                             info!(
                                 "[BRIDGE] Node position changed: {} -> {}:{} (was {}:{})",
                                 format_mac(&src_mac),
@@ -566,9 +612,7 @@ async fn espnow_bridge_task(
                                     messages_forwarded
                                 );
                             }
-                            Err(UsbError::NotReady) => {
-                                // Drop silently when USB host is not ready.
-                            }
+                            Err(UsbError::NotReady) => {}
                             Err(e) => {
                                 errors += 1;
                                 warn!("[BRIDGE] USB write error: {:?}", e);
@@ -584,13 +628,16 @@ async fn espnow_bridge_task(
                 // Log periodically
                 if messages_forwarded % 100 == 0 && messages_forwarded > 0 {
                     info!(
-                        "[BRIDGE] Stats: {} forwarded, {} errors",
-                        messages_forwarded, errors
+                        "[BRIDGE] Stats: {} forwarded, {} errors, {} timesyncs",
+                        messages_forwarded, errors, timesync_count
                     );
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!("[BRIDGE] Receive error: {:?}", e);
+            }
+            Err(_) => {
+                // Timeout -- loop back to poll USB RX
             }
         }
     }
@@ -602,7 +649,7 @@ async fn espnow_bridge_task(
 
 #[cfg(feature = "wifi")]
 async fn send_heartbeat(transceiver: &mut AirCommTransceiver<'static>) {
-    let timestamp_us = Instant::now().as_micros();
+    let timestamp_us = crate::timebase::synced_timestamp_us();
     let heartbeat = HeartbeatData::default();
 
     match transceiver
@@ -653,6 +700,12 @@ fn handle_received_message(msg: &SensorMessage) {
             info!(
                 "[ESP-NOW RX] GPS from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | time={}us, lat={:.6}, lon={:.6}",
                 src[0], src[1], src[2], src[3], src[4], src[5], timestamp, data.lat, data.lon
+            );
+        }
+        SensorPayload::TimeSync(data) => {
+            info!(
+                "[ESP-NOW RX] TimeSync from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | session={}us",
+                src[0], src[1], src[2], src[3], src[4], src[5], data.session_time_us
             );
         }
     }

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/devkit_c.rs
@@ -64,6 +64,8 @@ pub struct DevkitC {
     pub wifi: Option<WifiResources>,
     /// USB Serial TX for host communication (bridge mode)
     pub usb_serial_tx: Option<esp_hal::usb_serial_jtag::UsbSerialJtagTx<'static, esp_hal::Async>>,
+    /// USB Serial RX for receiving commands from host (bridge mode)
+    pub usb_serial_rx: Option<esp_hal::usb_serial_jtag::UsbSerialJtagRx<'static, esp_hal::Async>>,
 }
 
 impl DevkitC {
@@ -167,8 +169,8 @@ impl DevkitC {
         // and doesn't need explicit GPIO configuration
         let usb_serial =
             esp_hal::usb_serial_jtag::UsbSerialJtag::new(peripherals.USB_DEVICE).into_async();
-        let (_, usb_serial_tx) = usb_serial.split();
-        info!("USB Serial/JTAG initialized for bridge mode");
+        let (usb_serial_rx, usb_serial_tx) = usb_serial.split();
+        info!("USB Serial/JTAG initialized for bridge mode (TX + RX)");
 
         Self {
             #[cfg(feature = "hmi")]
@@ -184,6 +186,7 @@ impl DevkitC {
             #[cfg(feature = "wifi")]
             wifi,
             usb_serial_tx: Some(usb_serial_tx),
+            usb_serial_rx: Some(usb_serial_rx),
         }
     }
 }
@@ -238,6 +241,13 @@ impl BoardPeripherals for DevkitC {
     ) -> Option<esp_hal::usb_serial_jtag::UsbSerialJtagTx<'static, esp_hal::Async>> {
         trace!("usb_serial_tx take called");
         self.usb_serial_tx.take()
+    }
+
+    fn take_usb_serial_rx(
+        &mut self,
+    ) -> Option<esp_hal::usb_serial_jtag::UsbSerialJtagRx<'static, esp_hal::Async>> {
+        trace!("usb_serial_rx take called");
+        self.usb_serial_rx.take()
     }
 }
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -10,7 +10,7 @@ use esp_hal::gpio::Output;
 use esp_hal::spi::master::Spi;
 #[cfg(feature = "gps")]
 use esp_hal::uart::Uart;
-use esp_hal::usb_serial_jtag::UsbSerialJtagTx;
+use esp_hal::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};
 
 #[cfg(feature = "wifi")]
 pub mod aircomm;
@@ -81,6 +81,12 @@ pub trait BoardPeripherals {
     /// Take the USB Serial TX interface for host communication
     /// Returns None if USB is not available or not configured for this board
     fn take_usb_serial_tx(&mut self) -> Option<UsbSerialJtagTx<'static, Async>> {
-        None // Default: USB not available
+        None
+    }
+
+    /// Take the USB Serial RX interface for receiving commands from host
+    /// Returns None if USB RX is not available or not configured for this board
+    fn take_usb_serial_rx(&mut self) -> Option<UsbSerialJtagRx<'static, Async>> {
+        None
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/timebase.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use embassy_time::Instant;
 
 // Program start timestamp in milliseconds since an arbitrary epoch (Instant::now()).
@@ -22,4 +22,65 @@ pub fn elapsed_seconds() -> f32 {
     let start = PROGRAM_START_MS.load(Ordering::SeqCst);
     let elapsed_ms = now_ms.wrapping_sub(start) as u32;
     (elapsed_ms as f32) / 1000.0
+}
+
+// =========================================================================
+// Time synchronization
+// =========================================================================
+//
+// The sync offset converts local monotonic time to the RPi's session-elapsed
+// time.  Stored as two AtomicU32 halves (ESP32-C6 is 32-bit RISC-V, no
+// native 64-bit atomics) representing a signed i64 microsecond offset:
+//
+//   synced_us = local_us as i64 + offset
+//
+// Reads/writes use SeqCst ordering; tiny races between the two halves are
+// acceptable because apply_sync is called periodically and the offset
+// changes slowly (drift correction).
+
+static SYNC_OFFSET_LO: AtomicU32 = AtomicU32::new(0);
+static SYNC_OFFSET_HI: AtomicU32 = AtomicU32::new(0);
+static TIME_SYNCED: AtomicBool = AtomicBool::new(false);
+
+fn store_offset(offset: i64) {
+    let bits = offset as u64;
+    SYNC_OFFSET_LO.store(bits as u32, Ordering::SeqCst);
+    SYNC_OFFSET_HI.store((bits >> 32) as u32, Ordering::SeqCst);
+    TIME_SYNCED.store(true, Ordering::SeqCst);
+}
+
+fn load_offset() -> i64 {
+    let lo = SYNC_OFFSET_LO.load(Ordering::SeqCst) as u64;
+    let hi = SYNC_OFFSET_HI.load(Ordering::SeqCst) as u64;
+    ((hi << 32) | lo) as i64
+}
+
+/// Compute and store the sync offset from an RPi session timestamp.
+///
+/// Call this when a TimeSync message arrives.  The offset is:
+///   `rpi_session_time_us - Instant::now().as_micros()`
+///
+/// Subsequent calls update the offset (drift correction).
+pub fn apply_sync(rpi_session_time_us: u64) {
+    let local_us = Instant::now().as_micros() as i64;
+    let offset = rpi_session_time_us as i64 - local_us;
+    store_offset(offset);
+}
+
+/// Return a synchronized timestamp in microseconds.
+///
+/// If time sync has been applied, returns `local_us + offset` (the RPi
+/// session-elapsed time).  Otherwise falls back to raw `Instant::now()`.
+pub fn synced_timestamp_us() -> u64 {
+    if TIME_SYNCED.load(Ordering::SeqCst) {
+        let local_us = Instant::now().as_micros() as i64;
+        (local_us + load_offset()) as u64
+    } else {
+        Instant::now().as_micros()
+    }
+}
+
+/// Returns `true` once at least one TimeSync has been applied.
+pub fn is_time_synced() -> bool {
+    TIME_SYNCED.load(Ordering::SeqCst)
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
@@ -9,10 +9,13 @@ pub mod protocol;
 
 use embassy_time::{Duration, Instant, Timer};
 use esp_hal::Async;
-use esp_hal::usb_serial_jtag::UsbSerialJtagTx;
+use esp_hal::usb_serial_jtag::{UsbSerialJtagRx, UsbSerialJtagTx};
 use nb::Error as NbError;
 
-pub use protocol::{ForwardError, MAX_USB_MESSAGE_SIZE, format_mac, serialize_forwarded_message};
+pub use protocol::{
+    ForwardError, MAX_USB_MESSAGE_SIZE, UsbCommand, format_mac, parse_usb_command,
+    serialize_forwarded_message,
+};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
@@ -119,6 +122,69 @@ impl UsbSerial {
                     Timer::after(USB_WRITE_RETRY_DELAY).await;
                 }
                 Err(NbError::Other(_)) => return Err(UsbError::NotReady),
+            }
+        }
+    }
+}
+
+// =========================================================================
+// USB Serial RX (RPi -> Bridge commands)
+// =========================================================================
+
+/// COBS-decoded buffer size for incoming commands (largest command is 9 bytes)
+const USB_RX_DECODED_BUF_SIZE: usize = 32;
+/// Max COBS-encoded frame we'll accumulate before discarding
+const USB_RX_FRAME_MAX: usize = 64;
+
+/// USB Serial reader that accumulates COBS-framed commands from the host.
+pub struct UsbSerialRx {
+    rx: UsbSerialJtagRx<'static, Async>,
+    frame_buf: [u8; USB_RX_FRAME_MAX],
+    frame_len: usize,
+}
+
+impl UsbSerialRx {
+    pub fn new(rx: UsbSerialJtagRx<'static, Async>) -> Self {
+        Self {
+            rx,
+            frame_buf: [0u8; USB_RX_FRAME_MAX],
+            frame_len: 0,
+        }
+    }
+
+    /// Non-blocking poll: read any available bytes and try to decode a
+    /// complete COBS frame.  Returns `Some(cmd)` when a full command has
+    /// been received, `None` otherwise (no data or incomplete frame).
+    pub fn poll_command(&mut self) -> Option<UsbCommand> {
+        loop {
+            match self.rx.read_byte() {
+                Ok(0x00) => {
+                    // COBS delimiter -- decode the accumulated frame
+                    if self.frame_len == 0 {
+                        continue;
+                    }
+                    let mut decoded = [0u8; USB_RX_DECODED_BUF_SIZE];
+                    let result =
+                        cobs::decode(&self.frame_buf[..self.frame_len], &mut decoded);
+                    self.frame_len = 0;
+                    if let Ok(decoded_len) = result {
+                        if let Ok(cmd) = parse_usb_command(&decoded[..decoded_len]) {
+                            return Some(cmd);
+                        }
+                    }
+                    // Malformed frame -- discard and keep going
+                }
+                Ok(byte) => {
+                    if self.frame_len < USB_RX_FRAME_MAX {
+                        self.frame_buf[self.frame_len] = byte;
+                        self.frame_len += 1;
+                    } else {
+                        // Overflow -- discard frame
+                        self.frame_len = 0;
+                    }
+                }
+                Err(NbError::WouldBlock) => return None,
+                Err(NbError::Other(_)) => return None,
             }
         }
     }

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
@@ -118,6 +118,10 @@ pub fn serialize_forwarded_message(
             buffer[offset] = hb.magic;
             offset += 1;
         }
+        SensorPayload::TimeSync(_) => {
+            // TimeSync is not forwarded to USB host; bridge handles it internally
+            return Err(ForwardError::UnsupportedPayload);
+        }
     }
 
     Ok(offset)
@@ -140,4 +144,43 @@ pub fn format_mac(mac: &[u8; 6]) -> heapless::String<18> {
 pub enum ForwardError {
     /// Output buffer is too small
     BufferTooSmall,
+    /// Payload type cannot be forwarded over USB
+    UnsupportedPayload,
+}
+
+// =========================================================================
+// USB RX command protocol  (RPi -> Bridge)
+//
+// Commands are COBS-framed, same as the TX direction.
+// Format: [CommandType: 1B][Payload: variable]
+// =========================================================================
+
+/// USB command type byte values (RPi -> Bridge)
+pub const CMD_TIME_SYNC: u8 = 0x01;
+
+/// Parsed USB command from the RPi host
+#[derive(Debug, Clone, Copy)]
+pub enum UsbCommand {
+    /// TimeSync: RPi sends its session-elapsed time (microseconds)
+    TimeSync { session_time_us: u64 },
+}
+
+/// Parse a COBS-decoded command buffer into a `UsbCommand`.
+///
+/// Minimum size: 1 (command type) + 8 (payload for TimeSync) = 9 bytes.
+pub fn parse_usb_command(buffer: &[u8]) -> Result<UsbCommand, ForwardError> {
+    if buffer.is_empty() {
+        return Err(ForwardError::BufferTooSmall);
+    }
+
+    match buffer[0] {
+        CMD_TIME_SYNC => {
+            if buffer.len() < 9 {
+                return Err(ForwardError::BufferTooSmall);
+            }
+            let session_time_us = LittleEndian::read_u64(&buffer[1..]);
+            Ok(UsbCommand::TimeSync { session_time_us })
+        }
+        _ => Err(ForwardError::UnsupportedPayload),
+    }
 }

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
@@ -97,6 +97,22 @@ fn send_camera_command(command: &str) -> Result<String, Box<dyn std::error::Erro
     Ok(response.trim().to_string())
 }
 
+/// Query elapsed session time from camera server while it is recording.
+/// Expected response: `ELAPSED_US:<u64>` or `IDLE`.
+fn query_video_elapsed_us() -> Result<Option<u64>, Box<dyn std::error::Error>> {
+    let response = send_camera_command("status_us")?;
+    if response.eq_ignore_ascii_case("IDLE") {
+        return Ok(None);
+    }
+
+    if let Some(v) = response.strip_prefix("ELAPSED_US:") {
+        let us = v.trim().parse::<u64>()?;
+        return Ok(Some(us));
+    }
+
+    Err(format!("unexpected status_us response: {}", response).into())
+}
+
 /// Start video recording with a session-relative timestamp for post-processing correlation.
 /// Sends `start:<elapsed_us>` to the camera server.
 fn start_video_recording(session_start: &Instant) -> bool {
@@ -210,7 +226,38 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        let session_start = Instant::now();
+        // Session epoch defaults to now, but if video was already running first,
+        // adopt its elapsed monotonic offset so both systems share one epoch.
+        let mut session_start = Instant::now();
+        if video_recording.get() {
+            match query_video_elapsed_us() {
+                Ok(Some(video_elapsed_us)) => {
+                    let now = Instant::now();
+                    if let Some(adjusted_start) = now.checked_sub(Duration::from_micros(video_elapsed_us)) {
+                        session_start = adjusted_start;
+                        info!(
+                            "Adopted video session epoch: video_elapsed_us={} (data logger anchored to video clock)",
+                            video_elapsed_us
+                        );
+                    } else {
+                        warn!(
+                            "Video elapsed too large to back-calculate session start ({}us); keeping local epoch",
+                            video_elapsed_us
+                        );
+                    }
+                }
+                Ok(None) => {
+                    info!("Video status_us reported IDLE at session start; keeping local epoch");
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to query video status_us at session start ({}); keeping local epoch",
+                        e
+                    );
+                }
+            }
+        }
+
         let timesync_sender = TimeSyncSender::start(write_port, session_start);
         info!("TimeSyncSender started for session");
 

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
@@ -18,6 +18,7 @@ use std::fs;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
+use std::thread;
 use std::time::{Duration, Instant};
 
 const GPIO_INIT: u32 = 11;   // BCM 11: init / raw
@@ -260,6 +261,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let timesync_sender = TimeSyncSender::start(write_port, session_start);
         info!("TimeSyncSender started for session");
+
+        // Wait for the first TimeSync to propagate through the bridge to sensor nodes,
+        // then flush stale pre-sync data from the serial input buffer.
+        thread::sleep(Duration::from_millis(150));
+        if let Err(e) = read_port.clear(serialport::ClearBuffer::Input) {
+            warn!("Failed to clear serial input buffer: {}", e);
+        }
+        info!("Flushed serial input buffer after TimeSync propagation delay");
 
         let mut byte_source = SerialTimeoutByteSource::new(read_port);
         let mut should_stop = || {

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
@@ -12,12 +12,13 @@ use csv::Writer;
 use gpiod::{Chip, EdgeDetect, Options, Bias};
 use log::*;
 use rpi_rx_rust::session::{run_session, ByteSource};
+use rpi_rx_rust::TimeSyncSender;
 use std::cell::Cell;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const GPIO_INIT: u32 = 11;   // BCM 11: init / raw
 const GPIO_POST: u32 = 19;   // BCM 19: postprocessed logging
@@ -67,8 +68,18 @@ fn log_dir_for_today() -> PathBuf {
     }
 }
 
-fn serial_port() -> String {
+fn serial_port_name() -> String {
     std::env::var("RPI_RX_SERIAL_PORT").unwrap_or_else(|_| DEFAULT_SERIAL_PORT.to_string())
+}
+
+/// Open the serial port and clone it for bidirectional use.
+/// Returns `(read_port, write_port)` or an error.
+fn open_serial_bidirectional() -> Result<(Box<dyn serialport::SerialPort>, Box<dyn serialport::SerialPort>), serialport::Error> {
+    let port = serialport::new(serial_port_name(), DEFAULT_BAUD_RATE)
+        .timeout(Duration::from_millis(SERIAL_READ_TIMEOUT_MS))
+        .open()?;
+    let write_port = port.try_clone()?;
+    Ok((port, write_port))
 }
 
 /// Send command to the camera server (record.py)
@@ -76,14 +87,47 @@ fn send_camera_command(command: &str) -> Result<String, Box<dyn std::error::Erro
     let mut stream = TcpStream::connect(CAMERA_SERVER_ADDR)?;
     stream.set_write_timeout(Some(Duration::from_secs(2)))?;
     stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    
+
     stream.write_all(command.as_bytes())?;
     stream.flush()?;
-    
+
     let mut response = String::new();
     stream.read_to_string(&mut response)?;
-    
+
     Ok(response.trim().to_string())
+}
+
+/// Start video recording with a session-relative timestamp for post-processing correlation.
+/// Sends `start:<elapsed_us>` to the camera server.
+fn start_video_recording(session_start: &Instant) -> bool {
+    let elapsed_us = session_start.elapsed().as_micros();
+    let cmd = format!("start:{}", elapsed_us);
+    info!("Starting video recording (session offset {}us)", elapsed_us);
+    match send_camera_command(&cmd) {
+        Ok(response) => {
+            info!("Camera server response: {}", response);
+            true
+        }
+        Err(e) => {
+            error!("Failed to start video recording: {}", e);
+            false
+        }
+    }
+}
+
+/// Stop video recording.
+fn stop_video_recording() -> bool {
+    info!("Stopping video recording");
+    match send_camera_command("stop") {
+        Ok(response) => {
+            info!("Camera server response: {}", response);
+            true
+        }
+        Err(e) => {
+            error!("Failed to stop video recording: {}", e);
+            false
+        }
+    }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -100,28 +144,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .consumer("rpi_rx_rust_gpio");
     let mut inputs = chip.request_lines(opts)?;
     info!("GPIO {}, {}, and {} requested (edge both, pull-down enabled)", GPIO_INIT, GPIO_POST, GPIO_VIDEO);
-    
-    // Check initial state
+
     let initial_values: [bool; 3] = inputs.get_values([false, false, false])?;
-    info!("Initial GPIO state: GPIO{}={}, GPIO{}={}, GPIO{}={}", 
+    info!("Initial GPIO state: GPIO{}={}, GPIO{}={}, GPIO{}={}",
           GPIO_INIT, initial_values[0], GPIO_POST, initial_values[1], GPIO_VIDEO, initial_values[2]);
-    
-    // Track video recording state (using Cell for interior mutability in closure)
+
     let video_recording = Cell::new(false);
 
     loop {
-        // Idle: wait for an edge, then check GPIO states
         let _event = inputs.read_event()?;
         let values: [bool; 3] = inputs.get_values([false, false, false])?;
         let gpio11_high = values[0];
         let gpio19_high = values[1];
         let gpio26_high = values[2];
-        info!("GPIO edge detected: GPIO{}={}, GPIO{}={}, GPIO{}={}", 
+        info!("GPIO edge detected: GPIO{}={}, GPIO{}={}, GPIO{}={}",
               GPIO_INIT, gpio11_high, GPIO_POST, gpio19_high, GPIO_VIDEO, gpio26_high);
-        
-        // Handle video recording control (GPIO 26)
+
+        // Handle video recording control (GPIO 26) — outside session, no timestamp yet
         if gpio26_high && !video_recording.get() {
-            info!("GPIO {} high: starting video recording", GPIO_VIDEO);
+            info!("GPIO {} high: starting video recording (no active session)", GPIO_VIDEO);
             match send_camera_command("start") {
                 Ok(response) => {
                     info!("Camera server response: {}", response);
@@ -130,17 +171,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Err(e) => error!("Failed to start video recording: {}", e),
             }
         } else if !gpio26_high && video_recording.get() {
-            info!("GPIO {} low: stopping video recording", GPIO_VIDEO);
-            match send_camera_command("stop") {
-                Ok(response) => {
-                    info!("Camera server response: {}", response);
-                    video_recording.set(false);
-                }
-                Err(e) => error!("Failed to stop video recording: {}", e),
-            }
+            video_recording.set(!stop_video_recording());
         }
-        
-        // Check if data logging should be active (GPIO 11 or 19)
+
         let active = gpio11_high || gpio19_high;
         if !active {
             info!("Both GPIOs low, staying idle");
@@ -169,18 +202,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             None
         };
 
-        let port = match serialport::new(serial_port(), DEFAULT_BAUD_RATE)
-            .timeout(Duration::from_millis(SERIAL_READ_TIMEOUT_MS))
-            .open()
-        {
-            Ok(p) => p,
+        let (read_port, write_port) = match open_serial_bidirectional() {
+            Ok(ports) => ports,
             Err(e) => {
-                error!("Failed to open serial {}: {}", serial_port(), e);
+                error!("Failed to open serial {}: {}", serial_port_name(), e);
                 continue;
             }
         };
 
-        let mut byte_source = SerialTimeoutByteSource::new(port);
+        let session_start = Instant::now();
+        let timesync_sender = TimeSyncSender::start(write_port, session_start);
+        info!("TimeSyncSender started for session");
+
+        let mut byte_source = SerialTimeoutByteSource::new(read_port);
         let mut should_stop = || {
             let values: [bool; 3] = match inputs.get_values([false, false, false]) {
                 Ok(v) => v,
@@ -189,22 +223,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let gpio11 = values[0];
             let gpio19 = values[1];
             let gpio26 = values[2];
-            
-            // Handle video recording control (check periodically during session)
+
             if gpio26 && !video_recording.get() {
-                info!("GPIO {} high: starting video recording (during session)", GPIO_VIDEO);
-                if let Ok(response) = send_camera_command("start") {
-                    info!("Camera server response: {}", response);
-                    video_recording.set(true);
-                }
+                video_recording.set(start_video_recording(&session_start));
             } else if !gpio26 && video_recording.get() {
-                info!("GPIO {} low: stopping video recording (during session)", GPIO_VIDEO);
-                if let Ok(response) = send_camera_command("stop") {
-                    info!("Camera server response: {}", response);
-                    video_recording.set(false);
-                }
+                video_recording.set(!stop_video_recording());
             }
-            
+
             let active = gpio11 || gpio19;
             !active
         };
@@ -218,6 +243,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ) {
             error!("Session error: {}", e);
         }
+
+        timesync_sender.stop();
+        info!("TimeSyncSender stopped");
 
         drop(ahrs_wtr);
         drop(raw_wtr);

--- a/sw/tools/rpi_rx_rust/src/lib.rs
+++ b/sw/tools/rpi_rx_rust/src/lib.rs
@@ -2,8 +2,10 @@
 
 pub mod ahrs;
 pub mod session;
+pub mod timesync;
 pub mod types;
 
 pub use ahrs::{AhrsFilter, AhrsOutputRow};
 pub use session::{run_session, ByteSource};
+pub use timesync::{encode_timesync_command, TimeSyncSender};
 pub use types::{format_mac_address, parse_message, DecodedMessage, ParserError};

--- a/sw/tools/rpi_rx_rust/src/timesync.rs
+++ b/sw/tools/rpi_rx_rust/src/timesync.rs
@@ -1,0 +1,79 @@
+//! TimeSync sender: periodically sends COBS-framed TimeSync commands to the bridge via USB serial.
+//!
+//! Protocol matches firmware's `parse_usb_command` in sensor_board/src/usb/protocol.rs:
+//! Raw: [CMD_TIME_SYNC=0x01][session_time_us: u64 LE] → 9 bytes, then COBS-encode + 0x00 delimiter.
+
+use log::*;
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const CMD_TIME_SYNC: u8 = 0x01;
+const TIMESYNC_INTERVAL: Duration = Duration::from_millis(500);
+const RAW_CMD_LEN: usize = 9; // 1 cmd + 8 u64
+
+/// Build a COBS-framed USB TimeSync command: `COBS_ENCODE([0x01, session_time_us LE]) + [0x00]`.
+pub fn encode_timesync_command(session_time_us: u64) -> Vec<u8> {
+    let mut raw = [0u8; RAW_CMD_LEN];
+    raw[0] = CMD_TIME_SYNC;
+    raw[1..9].copy_from_slice(&session_time_us.to_le_bytes());
+
+    let max_encoded = cobs::max_encoding_length(RAW_CMD_LEN);
+    let mut encoded = vec![0u8; max_encoded + 1]; // +1 for 0x00 delimiter
+    let n = cobs::encode(&raw, &mut encoded);
+    encoded.truncate(n + 1);
+    encoded[n] = 0x00; // COBS frame delimiter
+    encoded
+}
+
+/// Periodic TimeSync sender running on a dedicated writer thread.
+pub struct TimeSyncSender {
+    stop_flag: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    session_start: Instant,
+}
+
+impl TimeSyncSender {
+    /// Spawn the sender thread. Begins sending immediately.
+    pub fn start(mut writer: Box<dyn serialport::SerialPort>, session_start: Instant) -> Self {
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let flag = stop_flag.clone();
+
+        let handle = thread::Builder::new()
+            .name("timesync-sender".into())
+            .spawn(move || {
+                info!("TimeSync sender started (interval={}ms)", TIMESYNC_INTERVAL.as_millis());
+                while !flag.load(Ordering::Relaxed) {
+                    let elapsed_us = session_start.elapsed().as_micros() as u64;
+                    let frame = encode_timesync_command(elapsed_us);
+                    if let Err(e) = writer.write_all(&frame) {
+                        warn!("TimeSync write error: {}", e);
+                    }
+                    thread::sleep(TIMESYNC_INTERVAL);
+                }
+                info!("TimeSync sender stopped");
+            })
+            .expect("failed to spawn timesync-sender thread");
+
+        Self {
+            stop_flag,
+            handle: Some(handle),
+            session_start,
+        }
+    }
+
+    /// Signal the thread to stop and join it.
+    pub fn stop(mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+
+    /// Returns the session start `Instant` (for video timestamp correlation).
+    pub fn session_start(&self) -> Instant {
+        self.session_start
+    }
+}


### PR DESCRIPTION
# What are changed?
- New time sync message in aircomm and usb
- In firmware, all nodes use time based on the monotonic clock at the rpi
- On rpi, it starts the monotonic clock whenever the sensor logging switch or video recording switch is pressed, stop the monotonic clock when both of them are off. Send timesync to the bridge board every half a second.

# How does time sync work
- Rpi rpi_rx_rust starts the monotonic clock whenever the operator starts logging (either sensor or video).
- When the other switch is pressed, the other system will keep using the same monotonic clock. This allows the sensor and video to share the same timestamp.
- Rpi sends a timesync message to the bridge board with the monotonic clock's time every half a second
- Once the bridge board receives the message, it broadcasts the time to all of the sensor nodes
- Sensor node calculates the difference between the node's time and the rpi's time. This difference will be applied to all of the future logging.

# Problem
- This PR doesn't have the change to the python video recording part of the code. ( alex set the repo to be private)
- This implementation has no involvement of GPS. Ideally, if the system has a gps time (a real time) we should be saving this information and matching this info with the system timestamp.
- The `rpi_rx_rust` still has the existing problem. There are two binary running as the daemon on rpi so far: one is the alex's video deamon; one is rpi_rx_rust. rpi_rx_rust is handling both the gpio monitoring and the sensor bridge message decode. These two functionalities should be decoupled to become two separate binaries in the future. 
- I didn't test the error of the timesync....There are surely some parts that would be optimized to decrease this error, but I don't know how large the error currently is. Don't know how to test it or if it's worth doing it at this point.