### PR TITLE
Add gps cone location capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
 # vehicle-daq
+
+Vehicle data-acquisition system: **ESP32-C6 sensor nodes** stream IMU and GPS over **ESP-NOW** to a **bridge**; the bridge forwards data over **USB** to a **Raspberry Pi**, which logs CSV, runs optional AHRS, and supports **track capture** (waypoint logging via a GPS-only “floating” node).
+
+The two main software pieces are:
+
+| Component | Location | Role |
+|-----------|----------|------|
+| **rpi_rx_rust** | [`sw/tools/rpi_rx_rust/`](sw/tools/rpi_rx_rust/) | Pi-side: COBS decoder, CSV logging, AHRS, track capture (GPIO or interactive). |
+| **sensor_board_rev1_test** | [`sw/sensor_board/sensor_board_rev1_test/`](sw/sensor_board/sensor_board_rev1_test/) | Firmware for Rev1 DAQ nodes (sensor + floating) and for the bridge (devkit). |
+
+---
+
+## System overview
+
+```mermaid
+flowchart TB
+  subgraph sensors["Sensor nodes"]
+    SN["rev1_board<br/>IMU + GPS"]
+  end
+
+  subgraph bridge["Bridge (devkit)"]
+    B["devkit_c<br/>Forward, TimeSync<br/>track heartbeats"]
+  end
+
+  subgraph host["Raspberry Pi"]
+    R["rpi_rx_rust<br/>Logs, AHRS<br/>track capture"]
+  end
+
+  subgraph floating["Floating node"]
+    F["sensorboard_floating<br/>GPS only"]
+  end
+
+  SN -->|"ESP-NOW (IMU, GPS, heartbeat)"| B
+  B -->|"USB COBS (forwarded messages)"| R
+  R -->|"TimeSync, Arm/End, RequestFloatingGps"| B
+  B -->|"TrackCaptureArmed/Ended (pause TX)"| SN
+  B -->|"RequestGpsCapture"| F
+  F -->|"5× GPS reply"| B
+  B -->|"heartbeat 0xFE (when armed)"| R
+```
+
+- **Sensor nodes** (`rev1_board`): Read IMU and GPS, send over ESP-NOW. When track capture is armed, they pause so the floating node’s packets aren’t dropped.
+- **Bridge** (`devkit_c`): Receives ESP-NOW, assigns node IDs by MAC, forwards messages to the Pi over USB (COBS). Sends TimeSync to nodes; handles Arm/End track and RequestFloatingGps; when armed, sends a track-capture heartbeat (0xFE) to the Pi every 500 ms.
+- **Floating node** (`sensorboard_floating`): GPS-only; on RequestGpsCapture it replies with the next 5 GPS samples for waypoint logging.
+- **Pi** (`rpi_rx_rust`): Decodes COBS stream, writes raw CSV (and optional AHRS CSV). Can arm track capture, request floating GPS per waypoint, and write track files (`~/daq/tracks/<date>/<time>.csv`). Uses track heartbeats to auto-end capture if the bridge disappears; bridge auto-ends if the Pi disappears.
+
+---
+
+## Raspberry Pi (rpi_rx_rust)
+
+- **Binaries**: `rpi_rx_rust` (CLI + serial), `rpi_rx_rust_gpio` (GPIO-only service), `rpi_rx_rust_track_test` (interactive track capture), `ahrs_postprocess`, `gps_extract`.
+- **Default serial**: `/dev/ttyACM0`, 115200 baud (set `RPI_RX_SERIAL_PORT` if the bridge is on another port).
+- **Logs**: `~/daq/logs/<date>/` (raw and AHRS); track files: `~/daq/tracks/<date>/`.
+- **Track capture**: Arm → take location (request 5 GPS from floating node, average, append one row) → end. Heartbeat from bridge (0xFE) every 500 ms; 3 s without heartbeat or 2 s without USB from Pi triggers auto-end.
+
+Full build and usage: **[sw/tools/rpi_rx_rust/README.md](sw/tools/rpi_rx_rust/README.md)**.
+
+---
+
+## Sensor board & bridge (sensor_board_rev1_test)
+
+- **Binaries**: `rev1_board` (sensor node), `devkit_c` (bridge), `sensorboard_floating` (GPS-only for track capture).
+- **Build** (from `sw/sensor_board/sensor_board_rev1_test/`):
+  - Sensor: `cargo build --bin rev1_board` (optional `--features pos_center` etc.).
+  - Bridge: `cargo build --bin devkit_c --no-default-features --features bridge`.
+  - Floating: `cargo build --bin sensorboard_floating --no-default-features --features floating`.
+- **HMI**: User LED (1 Hz) + NeoPixel (state/feedback). Bridge: 4× blink when armed; orange when sending request; green/rainbow on success/timeout. Floating: green breathing when idle with fix; orange when acquiring.
+
+Full build, features, task model, and hardware init: **[sw/sensor_board/sensor_board_rev1_test/README.md](sw/sensor_board/sensor_board_rev1_test/README.md)**.
+
+Other repos under `sw/`, `ee/`, and `vision/` may have their own READMEs.

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -11,6 +11,7 @@ default-run  = "rev1_board"
 [features]
 default = ["hmi", "imu", "gps", "wifi"]
 bridge  = ["hmi", "usb", "wifi"]
+floating = ["hmi", "gps", "wifi", "set_gps_10hz"]  # GPS-only node: wait for RequestGpsCapture, reply with 5 samples
 hmi = []      # User LED, NeoPixel, Display
 imu = []      # IMU sensor (SPI)
 gps = []      # GPS sensor (UART)
@@ -47,6 +48,11 @@ path = "./src/bin/sensorboard_rev1.rs"
 [[bin]]
 name = "devkit_c"
 path = "./src/bin/devkit_c.rs"
+
+[[bin]]
+name = "sensorboard_floating"
+path = "./src/bin/sensorboard_floating.rs"
+required-features = ["floating"]
 
 [dependencies]
 # esp-hal ecosystem - using git directly until crates.io catches up with async RMT API

--- a/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
+++ b/sw/sensor_board/sensor_board_rev1_test/Cargo.toml
@@ -9,9 +9,10 @@ version      = "0.1.0"
 default-run  = "rev1_board"
 
 [features]
-default = ["hmi", "imu", "gps", "wifi"]
-bridge  = ["hmi", "usb", "wifi"]
-floating = ["hmi", "gps", "wifi", "set_gps_10hz"]  # GPS-only node: wait for RequestGpsCapture, reply with 5 samples
+default = ["hmi", "imu", "gps", "wifi", "jtag-log"]
+bridge  = ["hmi", "usb", "wifi", "jtag-log"]   # Bridge: USB for RPi + log (default)
+bridge_uart_log = ["hmi", "usb", "wifi", "uart-log"]  # Bridge: USB for RPi only, log on UART (serial port)
+floating = ["hmi", "gps", "wifi", "set_gps_10hz", "jtag-log"]  # GPS-only node: wait for RequestGpsCapture, reply with 5 samples
 hmi = []      # User LED, NeoPixel, Display
 imu = []      # IMU sensor (SPI)
 gps = []      # GPS sensor (UART)
@@ -19,6 +20,9 @@ set_gps_high_baud = [] # Optional: configure GPS to high baudrate (non-default)
 set_gps_10hz = []      # Optional: configure GPS update rate to 10Hz (non-default)
 wifi = []     # WiFi/ESP-NOW wireless communication
 usb = []      # USB Serial for bridge data forwarding
+# Log output: exactly one of jtag-log (USB) or uart-log (UART) when building. For devkit with serial debug port use bridge_uart_log.
+jtag-log = ["esp-println/jtag-serial"]
+uart-log = ["esp-println/uart"]
 
 # Car position for sensor nodes (mutually exclusive - pick one)
 # Usage: --features "pos_front_left" or set in default features
@@ -62,7 +66,8 @@ esp-hal = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package 
 esp-rtos = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-rtos", features = ["esp32c6", "esp-alloc", "embassy", "esp-radio"] }
 esp-alloc = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-alloc" }
 esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-bootloader-esp-idf", features = ["esp32c6"] }
-esp-println = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-println", default-features = false, features = ["esp32c6", "log-04", "jtag-serial", "colors", "critical-section"] }
+# Log goes to JTAG (USB) by default; use uart-log feature for UART (e.g. devkit with serial debug port).
+esp-println = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-println", default-features = false, features = ["esp32c6", "log-04", "colors", "critical-section"] }
 
 # ESP-NOW wireless communication
 esp-radio = { git = "https://github.com/esp-rs/esp-hal", branch = "main", package = "esp-radio", features = ["esp32c6", "esp-now", "unstable", "esp-alloc"] }

--- a/sw/sensor_board/sensor_board_rev1_test/README.md
+++ b/sw/sensor_board/sensor_board_rev1_test/README.md
@@ -1,0 +1,105 @@
+# sensor_board_rev1_test
+
+ESP32-C6 sensor board firmware: data-acquisition nodes, USB bridge, and GPS-only “floating” node for track capture. Uses ESP-NOW for wireless data and COBS over USB to the Raspberry Pi.
+
+## Binaries
+
+| Binary | Purpose |
+|--------|--------|
+| `rev1_board` | **Sensor node**: streams IMU + GPS + heartbeat over ESP-NOW. Optional position feature (e.g. `pos_center`) for node ID. |
+| `devkit_c` | **Bridge**: receives ESP-NOW from nodes, forwards to host over USB serial (COBS). Accepts TimeSync and RequestFloatingGps from host. |
+| `sensorboard_floating` | **Floating (GPS-only) node**: waits for RequestGpsCapture over ESP-NOW, replies with the next 5 GPS samples. Used with RPi track capture. |
+
+## Build commands
+
+All builds from this directory (`sw/sensor_board/sensor_board_rev1_test/`).
+
+### Sensor node (default: HMI + IMU + GPS + WiFi)
+
+```bash
+# Default (includes hmi, imu, gps, wifi)
+cargo build --bin rev1_board
+
+# With car position (for node ID)
+cargo build --bin rev1_board --features pos_center
+# Other positions: pos_front_left, pos_front_center, pos_front_right, pos_left, pos_right,
+#                  pos_rear_left, pos_rear_center, pos_rear_right, pos_roof
+```
+
+### Bridge (USB forwarder for RPi)
+
+```bash
+cargo build --bin devkit_c --no-default-features --features bridge
+```
+
+### Floating node (GPS-only, track capture)
+
+```bash
+cargo build --bin sensorboard_floating --no-default-features --features floating
+```
+
+Build all three binaries in one go:
+
+```bash
+cargo build --bin rev1_board
+cargo build --bin devkit_c --no-default-features --features bridge
+cargo build --bin sensorboard_floating --no-default-features --features floating
+```
+
+### Optional features (sensor / floating)
+
+- `set_gps_high_baud`: configure GPS UART to 460800 (e.g. NEO-F10).
+- `set_gps_10hz`: set GPS to 10 Hz (floating feature already enables this).
+
+Example with high baud and 10 Hz on the default sensor node:
+
+```bash
+cargo build --bin rev1_board --features set_gps_high_baud,set_gps_10hz
+```
+
+## Features reference
+
+| Feature | Description |
+|---------|-------------|
+| `hmi` | User LED + NeoPixel (WS2812) + display SPI. |
+| `imu` | IMU over SPI (e.g. ASM330). |
+| `gps` | GPS over UART (NMEA). |
+| `wifi` | WiFi + ESP-NOW. |
+| `usb` | USB Serial/JTAG for bridge → host. |
+| `bridge` | Shorthand: `hmi`, `usb`, `wifi` (for devkit_c). |
+| `floating` | Shorthand: `hmi`, `gps`, `wifi`, `set_gps_10hz` (for sensorboard_floating). |
+| `pos_*` | Car position for node ID (pick one). |
+
+## HMI (user LED + NeoPixel)
+
+Hardware: **User LED** (GPIO19) and **NeoPixel** (GPIO18, WS2812).
+
+### User LED
+
+- Toggles at 1 Hz as a **heartbeat** on all binaries that enable HMI.
+
+### NeoPixel (sensor node `rev1_board` and bridge `devkit_c`)
+
+- **Color** reflects **IMU data age** (sensor node only; bridge runs HMI but has no IMU, so typically red/off):
+  - **Green**: IMU data &lt; 20 ms old.
+  - **Blue**: IMU data &lt; 10 s old.
+  - **Red**: No IMU or &gt; 10 s old.
+- **Pattern** reflects **GPS**:
+  - **Solid**: GPS fix (position valid).
+  - **Double pulse** (on 0.1 s, off 0.1 s, on 0.1 s, off 0.7 s): GPS connected, no fix.
+  - **Slow blink**: No GPS data (or no fix).
+
+### NeoPixel (floating node `sensorboard_floating`)
+
+- **Idle** (no capture in progress): same as above but **green only** (no IMU):
+  - **Solid green**: GPS fix.
+  - **Double-pulse green**: GPS connected, no fix.
+  - **Slow blink green**: No GPS data.
+- **Acquiring** (after RequestGpsCapture):
+  - **Solid orange** for 50 ms.
+  - Then **rapid orange blink** (~50 Hz) for up to ~600 ms while collecting 5 GPS samples.
+  - Then back to idle (green) behaviour.
+
+## Target
+
+ESP32-C6 (e.g. ESP32-C6-WROOM, DevKit-C). Flashing is typically done with `espflash` or the ESP-IDF toolchain; see the main vehicle-daq docs for flash layout and commands.

--- a/sw/sensor_board/sensor_board_rev1_test/README.md
+++ b/sw/sensor_board/sensor_board_rev1_test/README.md
@@ -28,9 +28,39 @@ cargo build --bin rev1_board --features pos_center
 
 ### Bridge (USB forwarder for RPi)
 
+By default, both **flashing/debug log** and **RPi communication** use the same USB (USB-JTAG):
+
 ```bash
 cargo build --bin devkit_c --no-default-features --features bridge
 ```
+
+If the devkit has a **separate serial port** (UART), you can send log output there and keep USB **only** for RPi/bridge traffic (flashing still over USB):
+
+```bash
+cargo build --bin devkit_c --no-default-features --features bridge_uart_log
+```
+
+- **`bridge`**: Log and RPi COBS both on USB. Use for a single USB connection.
+- **`bridge_uart_log`**: Log on UART (ROM default, typically UART0); RPi on USB. Connect a serial adapter to the UART port for `info!`/`warn!` etc., and plug USB to the RPi for clean COBS.
+
+**Viewing UART debug on Linux** (when using `bridge_uart_log`): the ROM UART console is usually **115200 8N1**. Find the serial device (e.g. `/dev/ttyUSB0` for an FTDI adapter, or the second port if the board exposes two):
+
+```bash
+# List serial ports (plug in the UART adapter, then run)
+ls /dev/ttyUSB* /dev/ttyACM* 2>/dev/null
+
+# Connect with picocom (Ctrl+A Ctrl+X to exit)
+picocom -b 115200 /dev/ttyUSB0
+
+# Or with screen
+screen /dev/ttyUSB0 115200
+# Detach: Ctrl+A then K, then Y
+
+# Or with minicom
+minicom -D /dev/ttyUSB0 -b 115200
+```
+
+Use the device that corresponds to the **UART/serial** connector (not the USB-JTAG port used for RPi or flashing).
 
 ### Floating node (GPS-only, track capture)
 
@@ -66,7 +96,8 @@ cargo build --bin rev1_board --features set_gps_high_baud,set_gps_10hz
 | `gps` | GPS over UART (NMEA). |
 | `wifi` | WiFi + ESP-NOW. |
 | `usb` | USB Serial/JTAG for bridge → host. |
-| `bridge` | Shorthand: `hmi`, `usb`, `wifi` (for devkit_c). |
+| `bridge` | Shorthand: `hmi`, `usb`, `wifi`, `jtag-log` (devkit_c; log + RPi on USB). |
+| `bridge_uart_log` | Like bridge but log on UART, RPi on USB only (for devkit with separate serial port). |
 | `floating` | Shorthand: `hmi`, `gps`, `wifi`, `set_gps_10hz` (for sensorboard_floating). |
 | `pos_*` | Car position for node ID (pick one). |
 

--- a/sw/sensor_board/sensor_board_rev1_test/README.md
+++ b/sw/sensor_board/sensor_board_rev1_test/README.md
@@ -1,14 +1,12 @@
 # sensor_board_rev1_test
 
-ESP32-C6 sensor board firmware: data-acquisition nodes, USB bridge, and GPS-only “floating” node for track capture. Uses ESP-NOW for wireless data and COBS over USB to the Raspberry Pi.
+This project was originally supposed to just be a test project for the ESP-HAL:1.0.0 release, but we continued to use it since it just worked and it kinda snowballed. You will find firmware for our Rev1 DAQ Nodes (ESP32-C6 based) operating both as sensor acquisition nodes and floating gps locator nodes, as well as firmware for ESP32-C6 devkits acting as our aircomm bridge board. In theory, a Rev1 DAQ node could act as a bridge node, except we messed up our board design so the second UART doesn't work :(.
 
 ## Binaries
 
-| Binary | Purpose |
-|--------|--------|
-| `rev1_board` | **Sensor node**: streams IMU + GPS + heartbeat over ESP-NOW. Optional position feature (e.g. `pos_center`) for node ID. |
-| `devkit_c` | **Bridge**: receives ESP-NOW from nodes, forwards to host over USB serial (COBS). Accepts TimeSync and RequestFloatingGps from host. |
-| `sensorboard_floating` | **Floating (GPS-only) node**: waits for RequestGpsCapture over ESP-NOW, replies with the next 5 GPS samples. Used with RPi track capture. |
+`rev1_board` | **Sensor node**: streams IMU + GPS + heartbeat over ESP-NOW. Pauses transmissions when track capture is armed (to avoid dropping floating-node packets). Optional position feature (e.g. `pos_center`) for node ID.
+`sensorboard_floating` | **Floating (GPS-only) Sensor node**: waits for RequestGpsCapture over ESP-NOW, replies with the next 5 GPS samples. Used with RPi track capture.
+`devkit_c` | **Bridge node**: receives ESP-NOW from nodes, forwards to host over USB (COBS). Accepts TimeSync, Arm/End track, RequestFloatingGps, CaptureSuccess/CaptureTimeout. When track capture is armed, sends a **track-capture heartbeat** (0xFE) to the Pi every 500 ms; if no USB from Pi for 2 s, auto-ends and broadcasts TrackCaptureEnded.
 
 ## Build commands
 
@@ -18,8 +16,8 @@ All builds from this directory (`sw/sensor_board/sensor_board_rev1_test/`).
 
 ```bash
 # Default (includes hmi, imu, gps, wifi)
+cargo run # You do not need to include anything, sensor node will run by default
 cargo build --bin rev1_board
-
 # With car position (for node ID)
 cargo build --bin rev1_board --features pos_center
 # Other positions: pos_front_left, pos_front_center, pos_front_right, pos_left, pos_right,
@@ -34,7 +32,7 @@ By default, both **flashing/debug log** and **RPi communication** use the same U
 cargo build --bin devkit_c --no-default-features --features bridge
 ```
 
-If the devkit has a **separate serial port** (UART), you can send log output there and keep USB **only** for RPi/bridge traffic (flashing still over USB):
+If the devkit has a separate serial port (UART), you can send log output there and keep USB for RPi/bridge traffic (flashing still over USB):
 
 ```bash
 cargo build --bin devkit_c --no-default-features --features bridge_uart_log
@@ -65,14 +63,6 @@ Use the device that corresponds to the **UART/serial** connector (not the USB-JT
 ### Floating node (GPS-only, track capture)
 
 ```bash
-cargo build --bin sensorboard_floating --no-default-features --features floating
-```
-
-Build all three binaries in one go:
-
-```bash
-cargo build --bin rev1_board
-cargo build --bin devkit_c --no-default-features --features bridge
 cargo build --bin sensorboard_floating --no-default-features --features floating
 ```
 
@@ -109,28 +99,112 @@ Hardware: **User LED** (GPIO19) and **NeoPixel** (GPIO18, WS2812).
 
 - Toggles at 1 Hz as a **heartbeat** on all binaries that enable HMI.
 
-### NeoPixel (sensor node `rev1_board` and bridge `devkit_c`)
+### NeoPixel
 
-- **Color** reflects **IMU data age** (sensor node only; bridge runs HMI but has no IMU, so typically red/off):
-  - **Green**: IMU data &lt; 20 ms old.
-  - **Blue**: IMU data &lt; 10 s old.
-  - **Red**: No IMU or &gt; 10 s old.
-- **Pattern** reflects **GPS**:
-  - **Solid**: GPS fix (position valid).
-  - **Double pulse** (on 0.1 s, off 0.1 s, on 0.1 s, off 0.7 s): GPS connected, no fix.
-  - **Slow blink**: No GPS data (or no fix).
+**Bridge (`devkit_c`)**: No IMU/GPS; LED reflects bridge state:
+  - **Armed** (track capture): **4×** blink rate (red).
+  - **Sending request**: **Orange**.
+  - **Success** (Pi got 5 GPS): **Solid green** for 1 s.
+  - **Timeout** (Pi did not get 5 GPS): **Rainbow** for 1 s.
 
-### NeoPixel (floating node `sensorboard_floating`)
+**Sensor node (`rev1_board`)**:
+  - **Color** by IMU data age: **Green** &lt; 20 ms, **Blue** &lt; 10 s, **Red** otherwise.
+  - **Pattern** by GPS: **Solid** = fix; **Double pulse** = connected no fix; **Slow blink** = no GPS.
+  - When **GPS fix** and idle: **Green breathing** (25% → 100% brightness, 2 s cycle).
 
-- **Idle** (no capture in progress): same as above but **green only** (no IMU):
-  - **Solid green**: GPS fix.
+**Sensorode (`floating`)**:
+- **Idle** (no capture in progress), **green only** (no IMU):
+  - **GPS fix**: **Green breathing** (25% → 100% brightness, 2 s cycle).
   - **Double-pulse green**: GPS connected, no fix.
   - **Slow blink green**: No GPS data.
 - **Acquiring** (after RequestGpsCapture):
-  - **Solid orange** for 50 ms.
-  - Then **rapid orange blink** (~50 Hz) for up to ~600 ms while collecting 5 GPS samples.
+  - **Solid orange** for **500 ms** (operator notice).
+  - Then **rapid orange blink** for up to ~2 s while collecting 5 GPS samples.
   - Then back to idle (green) behaviour.
 
-## Target
+## Task management
 
-ESP32-C6 (e.g. ESP32-C6-WROOM, DevKit-C). Flashing is typically done with `espflash` or the ESP-IDF toolchain; see the main vehicle-daq docs for flash layout and commands.
+Firmware uses the **Embassy** async executor. Each binary spawns a fixed set of tasks; the main coroutine then sleeps in a loop so the process does not exit.
+
+### Sensor node (`rev1_board`)
+
+| Task | Role |
+|------|------|
+| **IMU** | Reads IMU over SPI at fixed rate; pushes `ImuData` into `SENSOR_CHANNEL`. |
+| **GPS** | After `init_gps`, reads NMEA from UART; pushes `GpsData` into `SENSOR_CHANNEL`. |
+| **ESP-NOW sender** | Pulls from `SENSOR_CHANNEL` (capacity 8), sends IMU/GPS over ESP-NOW. Also receives TimeSync and TrackCaptureArmed/Ended; when armed, pauses sending so the floating node’s packets are not dropped. Sends periodic heartbeats. |
+| **HMI** | Reads `HMI_STATE` (mutex), drives user LED (1 Hz) and NeoPixel (color/pattern by IMU age and GPS). |
+
+Shared state: `SENSOR_CHANNEL` (Channel), `HMI_STATE` (mutex), `TRACK_CAPTURE_ARMED` (atomic), timebase (program start + sync offset).
+
+### Bridge (`devkit_c`)
+
+| Task | Role |
+|------|------|
+| **ESP-NOW bridge** | Polls USB RX for commands (TimeSync, Arm/End track, RequestFloatingGps, CaptureSuccess/Timeout); when armed, sends track-capture heartbeat (0xFE) to the Pi every 500 ms; receives ESP-NOW, assigns NodeIds by MAC discovery, forwards messages to USB (COBS). Auto-ends track capture if no USB from Pi for 2 s. |
+| **HMI** | Drives LED/NeoPixel from `HMI_STATE` (armed blink, orange/green/rainbow feedback). |
+
+Before the bridge task is spawned, the app waits up to 3 s for USB host presence (SOF interrupt), with a rainbow NeoPixel animation.
+
+### Floating node (`sensorboard_floating`)
+
+| Task | Role |
+|------|------|
+| **ESP-NOW** | Listens for RequestGpsCapture; sets `CAPTURE_MODE`, collects 5 GPS from `CAPTURE_CHANNEL`, replies with 5 GpsData messages. |
+| **GPS** | Optional baud detection (floating feature) then NMEA parsing; pushes GGA-derived `GpsData` to `CAPTURE_CHANNEL` when in capture mode, and updates `HMI_STATE` (fix, last timestamp). |
+| **HMI floating** | User LED 1 Hz; NeoPixel: green breathing when idle with fix, orange when acquiring. |
+| **GPS stale watchdog** | Every 1 s, warns if no GGA in 1 s, errors if none in 5 s. |
+
+Shared state: `CAPTURE_CHANNEL` (capacity 5), `CAPTURE_MODE` (atomic), `HMI_STATE`.
+
+---
+
+## Board hardware initialization
+
+Initialization is driven by the **`BoardPeripherals`** trait: each board (Rev1, DevkitC, Floating) implements `take_*` methods that hand out peripherals once. The app calls them in a fixed order so that tasks receive owned resources.
+
+### Order in `app_run` (sensor node / bridge)
+
+1. **Timebase** — `set_program_start()` (used for elapsed time and sync).
+2. **HMI** — `take_user_led()`, `take_neopixel()`; 3 s rainbow on NeoPixel (all binaries).
+3. **Display SPI** — `take_disp_spi_device()` (held but not used by current tasks).
+4. **IMU** — `take_imu_spi_device()` (sensor node only).
+5. **GPS** — `take_gps2_uart()`; then `init_gps()` (configures NMEA/UBX, 10 Hz, etc.).
+6. **WiFi** — `take_wifi()`; create `AirCommTransceiver`, then spawn ESP-NOW task(s).
+7. **USB** — (Bridge only) `take_usb_serial_tx()`, `take_usb_serial_rx()`; wait for host, then spawn bridge task.
+8. **HMI task** — spawned last with user_led and neopixel.
+
+### Order in `app_run_floating`
+
+1. Timebase, user_led, neopixel, 3 s rainbow.
+2. `take_disp_spi_device()`, then GPS: if `take_gps2_uart_blocking()` is `Some`, run **baud detection** (9600, 38400, 115200, 460800) and then switch to async UART; else `init_gps(take_gps2_uart())`.
+3. WiFi, ESP-NOW task, GPS task, HMI floating task, GPS stale watchdog.
+
+### Rev1 hardware mapping
+
+| Peripheral | Pin / config |
+|------------|----------------|
+| User LED | GPIO19 |
+| NeoPixel (WS2812) | GPIO18, RMT, 80 MHz |
+| GPS UART | UART1, default 460800, RX=GPIO23, TX=GPIO22 |
+| SPI (IMU + display) | SPI2, 100 kHz, Mode 0; SCK=6, MOSI=7, MISO=0; IMU CS=GPIO1, display CS=GPIO10 |
+
+### DevkitC (bridge)
+
+Same idea; NeoPixel often on GPIO8. USB Serial/JTAG for host; no IMU/GPS in normal bridge use. UART1 at 9600 if present.
+
+---
+
+## Multi-node synchronization
+
+### TimeSync (RPi session time)
+
+The Raspberry Pi sends **TimeSync** over USB (session time in microseconds). The bridge receives it and **broadcasts** the same TimeSync on ESP-NOW. Data nodes (sender or transceiver) receive it and call `timebase::apply_sync(session_time_us)`. All nodes then use `timebase::synced_timestamp_us()` for message timestamps, so logs and forwarded data are aligned to the Pi’s session clock. If no TimeSync has been applied yet, `synced_timestamp_us()` falls back to local monotonic time.
+
+### Node identity on the bridge
+
+The bridge does **not** configure node IDs; each node sends a **Heartbeat** with its configured position (e.g. FrontLeft, Center, Floating). On first Heartbeat from a given MAC, the bridge assigns an **instance** number (0, 1, …) per position and builds a `mac_to_node_id` map. All messages forwarded to the Pi carry this (position, instance) so the host can distinguish multiple nodes of the same type.
+
+### Track capture coordination
+
+When the Pi arms track capture, it sends **ArmTrack**; the bridge sets `track_armed`, broadcasts **TrackCaptureArmed** on ESP-NOW, and starts sending **track-capture heartbeats** (0xFE) to the Pi every 500 ms. Non-floating nodes receive TrackCaptureArmed and set `TRACK_CAPTURE_ARMED`; they then **pause** IMU/GPS/heartbeat transmission until **TrackCaptureEnded**. That keeps the air clear for the floating node’s 5 GPS replies. When the Pi ends capture (or the bridge times out after 2 s without USB), the bridge broadcasts TrackCaptureEnded and nodes resume.

--- a/sw/sensor_board/sensor_board_rev1_test/README.md
+++ b/sw/sensor_board/sensor_board_rev1_test/README.md
@@ -4,9 +4,11 @@ This project was originally supposed to just be a test project for the ESP-HAL:1
 
 ## Binaries
 
-`rev1_board` | **Sensor node**: streams IMU + GPS + heartbeat over ESP-NOW. Pauses transmissions when track capture is armed (to avoid dropping floating-node packets). Optional position feature (e.g. `pos_center`) for node ID.
-`sensorboard_floating` | **Floating (GPS-only) Sensor node**: waits for RequestGpsCapture over ESP-NOW, replies with the next 5 GPS samples. Used with RPi track capture.
-`devkit_c` | **Bridge node**: receives ESP-NOW from nodes, forwards to host over USB (COBS). Accepts TimeSync, Arm/End track, RequestFloatingGps, CaptureSuccess/CaptureTimeout. When track capture is armed, sends a **track-capture heartbeat** (0xFE) to the Pi every 500 ms; if no USB from Pi for 2 s, auto-ends and broadcasts TrackCaptureEnded.
+| Binary | Purpose |
+|--------|--------|
+| `rev1_board` | **Sensor node**: streams IMU + GPS + heartbeat over ESP-NOW. Pauses transmissions when track capture is armed (to avoid dropping floating-node packets). Optional position feature (e.g. `pos_center`) for node ID. |
+| `sensorboard_floating` | **Floating (GPS-only) Sensor node**: waits for RequestGpsCapture over ESP-NOW, replies with the next 5 GPS samples. Used with RPi track capture. |
+| `devkit_c` | **Bridge node**: receives ESP-NOW from nodes, forwards to host over USB (COBS). Accepts TimeSync, Arm/End track, RequestFloatingGps, CaptureSuccess/CaptureTimeout. When track capture is armed, sends a **track-capture heartbeat** (0xFE) to the Pi every 500 ms; if no USB from Pi for 2 s, auto-ends and broadcasts TrackCaptureEnded. |
 
 ## Build commands
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
@@ -14,6 +14,8 @@ pub enum MessageType {
     Imu = 0x01,
     /// GPS sensor data
     Gps = 0x02,
+    /// Request floating GPS capture: bridge broadcasts, floating node replies with 5 GPS samples
+    RequestGpsCapture = 0xFD,
     /// Time synchronization from bridge/RPi
     TimeSync = 0xFE,
     /// Heartbeat/keep-alive message
@@ -25,6 +27,7 @@ impl MessageType {
         match value {
             0x01 => Some(MessageType::Imu),
             0x02 => Some(MessageType::Gps),
+            0xFD => Some(MessageType::RequestGpsCapture),
             0xFE => Some(MessageType::TimeSync),
             0xFF => Some(MessageType::Heartbeat),
             _ => None,
@@ -116,6 +119,8 @@ pub struct SensorMessage {
 pub enum SensorPayload {
     Imu(ImuData),
     Gps(GpsData),
+    /// Request to capture next 5 GPS samples (no payload; bridge -> floating)
+    RequestGpsCapture,
     Heartbeat(HeartbeatData),
     TimeSync(TimeSyncData),
 }
@@ -125,6 +130,7 @@ impl SensorPayload {
         match self {
             SensorPayload::Imu(_) => MessageType::Imu,
             SensorPayload::Gps(_) => MessageType::Gps,
+            SensorPayload::RequestGpsCapture => MessageType::RequestGpsCapture,
             SensorPayload::Heartbeat(_) => MessageType::Heartbeat,
             SensorPayload::TimeSync(_) => MessageType::TimeSync,
         }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
@@ -16,6 +16,10 @@ pub enum MessageType {
     Gps = 0x02,
     /// Request floating GPS capture: bridge broadcasts, floating node replies with 5 GPS samples
     RequestGpsCapture = 0xFD,
+    /// Track capture ended: bridge broadcasts, data nodes resume transmissions
+    TrackCaptureEnded = 0xFC,
+    /// Track capture armed: bridge broadcasts, data nodes (non-floating) pause transmissions
+    TrackCaptureArmed = 0xFB,
     /// Time synchronization from bridge/RPi
     TimeSync = 0xFE,
     /// Heartbeat/keep-alive message
@@ -28,6 +32,8 @@ impl MessageType {
             0x01 => Some(MessageType::Imu),
             0x02 => Some(MessageType::Gps),
             0xFD => Some(MessageType::RequestGpsCapture),
+            0xFC => Some(MessageType::TrackCaptureEnded),
+            0xFB => Some(MessageType::TrackCaptureArmed),
             0xFE => Some(MessageType::TimeSync),
             0xFF => Some(MessageType::Heartbeat),
             _ => None,
@@ -121,6 +127,10 @@ pub enum SensorPayload {
     Gps(GpsData),
     /// Request to capture next 5 GPS samples (no payload; bridge -> floating)
     RequestGpsCapture,
+    /// Track capture armed: non-floating nodes pause transmissions (bridge -> all)
+    TrackCaptureArmed,
+    /// Track capture ended: non-floating nodes resume (bridge -> all)
+    TrackCaptureEnded,
     Heartbeat(HeartbeatData),
     TimeSync(TimeSyncData),
 }
@@ -131,6 +141,8 @@ impl SensorPayload {
             SensorPayload::Imu(_) => MessageType::Imu,
             SensorPayload::Gps(_) => MessageType::Gps,
             SensorPayload::RequestGpsCapture => MessageType::RequestGpsCapture,
+            SensorPayload::TrackCaptureArmed => MessageType::TrackCaptureArmed,
+            SensorPayload::TrackCaptureEnded => MessageType::TrackCaptureEnded,
             SensorPayload::Heartbeat(_) => MessageType::Heartbeat,
             SensorPayload::TimeSync(_) => MessageType::TimeSync,
         }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/message.rs
@@ -14,12 +14,12 @@ pub enum MessageType {
     Imu = 0x01,
     /// GPS sensor data
     Gps = 0x02,
-    /// Request floating GPS capture: bridge broadcasts, floating node replies with 5 GPS samples
-    RequestGpsCapture = 0xFD,
-    /// Track capture ended: bridge broadcasts, data nodes resume transmissions
-    TrackCaptureEnded = 0xFC,
     /// Track capture armed: bridge broadcasts, data nodes (non-floating) pause transmissions
     TrackCaptureArmed = 0xFB,
+    /// Track capture ended: bridge broadcasts, data nodes resume transmissions
+    TrackCaptureEnded = 0xFC,
+    /// Request floating GPS capture: bridge broadcasts, floating node replies with 5 GPS samples
+    RequestGpsCapture = 0xFD,
     /// Time synchronization from bridge/RPi
     TimeSync = 0xFE,
     /// Heartbeat/keep-alive message
@@ -31,9 +31,9 @@ impl MessageType {
         match value {
             0x01 => Some(MessageType::Imu),
             0x02 => Some(MessageType::Gps),
-            0xFD => Some(MessageType::RequestGpsCapture),
-            0xFC => Some(MessageType::TrackCaptureEnded),
             0xFB => Some(MessageType::TrackCaptureArmed),
+            0xFC => Some(MessageType::TrackCaptureEnded),
+            0xFD => Some(MessageType::RequestGpsCapture),
             0xFE => Some(MessageType::TimeSync),
             0xFF => Some(MessageType::Heartbeat),
             _ => None,
@@ -125,14 +125,14 @@ pub struct SensorMessage {
 pub enum SensorPayload {
     Imu(ImuData),
     Gps(GpsData),
-    /// Request to capture next 5 GPS samples (no payload; bridge -> floating)
-    RequestGpsCapture,
     /// Track capture armed: non-floating nodes pause transmissions (bridge -> all)
     TrackCaptureArmed,
     /// Track capture ended: non-floating nodes resume (bridge -> all)
     TrackCaptureEnded,
-    Heartbeat(HeartbeatData),
+    /// Request to capture next 5 GPS samples (no payload; bridge -> floating)
+    RequestGpsCapture,
     TimeSync(TimeSyncData),
+    Heartbeat(HeartbeatData),
 }
 
 impl SensorPayload {
@@ -140,11 +140,11 @@ impl SensorPayload {
         match self {
             SensorPayload::Imu(_) => MessageType::Imu,
             SensorPayload::Gps(_) => MessageType::Gps,
-            SensorPayload::RequestGpsCapture => MessageType::RequestGpsCapture,
             SensorPayload::TrackCaptureArmed => MessageType::TrackCaptureArmed,
             SensorPayload::TrackCaptureEnded => MessageType::TrackCaptureEnded,
-            SensorPayload::Heartbeat(_) => MessageType::Heartbeat,
+            SensorPayload::RequestGpsCapture => MessageType::RequestGpsCapture,
             SensorPayload::TimeSync(_) => MessageType::TimeSync,
+            SensorPayload::Heartbeat(_) => MessageType::Heartbeat,
         }
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
@@ -74,6 +74,15 @@ impl<'a> AirCommTransceiver<'a> {
         sender::send_timesync(&mut self.esp_now, timestamp_us, data, peer_addr).await
     }
 
+    /// Broadcast request for floating GPS capture (bridge -> floating node)
+    pub async fn send_request_gps_capture(
+        &mut self,
+        timestamp_us: u64,
+        peer_addr: &[u8; 6],
+    ) -> Result<()> {
+        sender::send_request_gps_capture(&mut self.esp_now, timestamp_us, peer_addr).await
+    }
+
     /// Receive sensor data (suspends until data arrives)
     pub async fn receive(&mut self) -> Result<SensorMessage> {
         receiver::receive(&mut self.esp_now).await

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/mod.rs
@@ -83,6 +83,24 @@ impl<'a> AirCommTransceiver<'a> {
         sender::send_request_gps_capture(&mut self.esp_now, timestamp_us, peer_addr).await
     }
 
+    /// Broadcast track capture armed (bridge -> all; non-floating nodes pause)
+    pub async fn send_track_capture_armed(
+        &mut self,
+        timestamp_us: u64,
+        peer_addr: &[u8; 6],
+    ) -> Result<()> {
+        sender::send_track_capture_armed(&mut self.esp_now, timestamp_us, peer_addr).await
+    }
+
+    /// Broadcast track capture ended (bridge -> all; non-floating nodes resume)
+    pub async fn send_track_capture_ended(
+        &mut self,
+        timestamp_us: u64,
+        peer_addr: &[u8; 6],
+    ) -> Result<()> {
+        sender::send_track_capture_ended(&mut self.esp_now, timestamp_us, peer_addr).await
+    }
+
     /// Receive sensor data (suspends until data arrives)
     pub async fn receive(&mut self) -> Result<SensorMessage> {
         receiver::receive(&mut self.esp_now).await

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -274,11 +274,11 @@ pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
     let payload = match msg_type {
         MessageType::Imu => deserialize_imu(data, payload_offset)?,
         MessageType::Gps => deserialize_gps(data, payload_offset)?,
-        MessageType::RequestGpsCapture => SensorPayload::RequestGpsCapture,
         MessageType::TrackCaptureArmed => SensorPayload::TrackCaptureArmed,
         MessageType::TrackCaptureEnded => SensorPayload::TrackCaptureEnded,
-        MessageType::Heartbeat => deserialize_heartbeat(data, payload_offset)?,
+        MessageType::RequestGpsCapture => SensorPayload::RequestGpsCapture,
         MessageType::TimeSync => deserialize_timesync(data, payload_offset)?,
+        MessageType::Heartbeat => deserialize_heartbeat(data, payload_offset)?,
     };
 
     Ok(SensorMessage {

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -214,6 +214,22 @@ pub fn serialize_timesync(
     Ok(offset)
 }
 
+/// RequestGpsCapture has no payload; header only (9 bytes)
+pub const REQUEST_GPS_CAPTURE_SIZE: usize = HEADER_SIZE;
+
+/// Serialize RequestGpsCapture (header only)
+pub fn serialize_request_gps_capture(
+    timestamp_us: u64,
+    buffer: &mut [u8],
+) -> Result<usize> {
+    if buffer.len() < REQUEST_GPS_CAPTURE_SIZE {
+        return Err(AirCommError::BufferTooSmall);
+    }
+    buffer[0] = MessageType::RequestGpsCapture.to_u8();
+    LittleEndian::write_u64(&mut buffer[1..], timestamp_us);
+    Ok(REQUEST_GPS_CAPTURE_SIZE)
+}
+
 /// Deserialize received data into a sensor message
 ///
 /// Reads the message type header, timestamp, and deserializes the appropriate payload
@@ -238,6 +254,7 @@ pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
     let payload = match msg_type {
         MessageType::Imu => deserialize_imu(data, payload_offset)?,
         MessageType::Gps => deserialize_gps(data, payload_offset)?,
+        MessageType::RequestGpsCapture => SensorPayload::RequestGpsCapture,
         MessageType::Heartbeat => deserialize_heartbeat(data, payload_offset)?,
         MessageType::TimeSync => deserialize_timesync(data, payload_offset)?,
     };

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/protocol.rs
@@ -230,6 +230,26 @@ pub fn serialize_request_gps_capture(
     Ok(REQUEST_GPS_CAPTURE_SIZE)
 }
 
+/// Serialize TrackCaptureArmed (header only)
+pub fn serialize_track_capture_armed(timestamp_us: u64, buffer: &mut [u8]) -> Result<usize> {
+    if buffer.len() < HEADER_SIZE {
+        return Err(AirCommError::BufferTooSmall);
+    }
+    buffer[0] = MessageType::TrackCaptureArmed.to_u8();
+    LittleEndian::write_u64(&mut buffer[1..], timestamp_us);
+    Ok(HEADER_SIZE)
+}
+
+/// Serialize TrackCaptureEnded (header only)
+pub fn serialize_track_capture_ended(timestamp_us: u64, buffer: &mut [u8]) -> Result<usize> {
+    if buffer.len() < HEADER_SIZE {
+        return Err(AirCommError::BufferTooSmall);
+    }
+    buffer[0] = MessageType::TrackCaptureEnded.to_u8();
+    LittleEndian::write_u64(&mut buffer[1..], timestamp_us);
+    Ok(HEADER_SIZE)
+}
+
 /// Deserialize received data into a sensor message
 ///
 /// Reads the message type header, timestamp, and deserializes the appropriate payload
@@ -255,6 +275,8 @@ pub fn deserialize(data: &[u8], src_address: [u8; 6]) -> Result<SensorMessage> {
         MessageType::Imu => deserialize_imu(data, payload_offset)?,
         MessageType::Gps => deserialize_gps(data, payload_offset)?,
         MessageType::RequestGpsCapture => SensorPayload::RequestGpsCapture,
+        MessageType::TrackCaptureArmed => SensorPayload::TrackCaptureArmed,
+        MessageType::TrackCaptureEnded => SensorPayload::TrackCaptureEnded,
         MessageType::Heartbeat => deserialize_heartbeat(data, payload_offset)?,
         MessageType::TimeSync => deserialize_timesync(data, payload_offset)?,
     };

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
@@ -6,7 +6,8 @@
 use super::error::Result;
 use super::message::*;
 use super::protocol::{
-    MAX_PAYLOAD_SIZE, serialize_gps, serialize_heartbeat, serialize_imu, serialize_timesync,
+    serialize_request_gps_capture, MAX_PAYLOAD_SIZE, serialize_gps, serialize_heartbeat,
+    serialize_imu, serialize_timesync,
 };
 use esp_radio::esp_now::EspNow;
 
@@ -70,5 +71,17 @@ pub(crate) async fn send_timesync(
 
     esp_now.send_async(peer_addr, &buffer[..size]).await?;
 
+    Ok(())
+}
+
+/// Broadcast request for floating node to capture and send 5 GPS samples (bridge -> floating)
+pub(crate) async fn send_request_gps_capture(
+    esp_now: &mut EspNow<'_>,
+    timestamp_us: u64,
+    peer_addr: &[u8; 6],
+) -> Result<()> {
+    let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
+    let size = serialize_request_gps_capture(timestamp_us, &mut buffer)?;
+    esp_now.send_async(peer_addr, &buffer[..size]).await?;
     Ok(())
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/aircomm/sender.rs
@@ -6,8 +6,8 @@
 use super::error::Result;
 use super::message::*;
 use super::protocol::{
-    serialize_request_gps_capture, MAX_PAYLOAD_SIZE, serialize_gps, serialize_heartbeat,
-    serialize_imu, serialize_timesync,
+    serialize_request_gps_capture, serialize_track_capture_armed, serialize_track_capture_ended,
+    MAX_PAYLOAD_SIZE, serialize_gps, serialize_heartbeat, serialize_imu, serialize_timesync,
 };
 use esp_radio::esp_now::EspNow;
 
@@ -82,6 +82,30 @@ pub(crate) async fn send_request_gps_capture(
 ) -> Result<()> {
     let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
     let size = serialize_request_gps_capture(timestamp_us, &mut buffer)?;
+    esp_now.send_async(peer_addr, &buffer[..size]).await?;
+    Ok(())
+}
+
+/// Broadcast track capture armed: non-floating nodes pause transmissions (bridge -> all)
+pub(crate) async fn send_track_capture_armed(
+    esp_now: &mut EspNow<'_>,
+    timestamp_us: u64,
+    peer_addr: &[u8; 6],
+) -> Result<()> {
+    let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
+    let size = serialize_track_capture_armed(timestamp_us, &mut buffer)?;
+    esp_now.send_async(peer_addr, &buffer[..size]).await?;
+    Ok(())
+}
+
+/// Broadcast track capture ended: non-floating nodes resume (bridge -> all)
+pub(crate) async fn send_track_capture_ended(
+    esp_now: &mut EspNow<'_>,
+    timestamp_us: u64,
+    peer_addr: &[u8; 6],
+) -> Result<()> {
+    let mut buffer = [0u8; MAX_PAYLOAD_SIZE];
+    let size = serialize_track_capture_ended(timestamp_us, &mut buffer)?;
     esp_now.send_async(peer_addr, &buffer[..size]).await?;
     Ok(())
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -251,9 +251,12 @@ pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mu
     // FIXME: Moving this here so that esp-now can be handled within app.rs
     // NOTE: this is not correct behaviour, but it'll be ok ish for now
     #[cfg(feature = "hmi")]
-    spawner
-        .spawn(start_hmi_task(user_led, neopixel))
-        .expect("HMI task did not spawn");
+    {
+        info!("[HMI] Spawning HMI task (user LED + NeoPixel)");
+        spawner
+            .spawn(start_hmi_task(user_led, neopixel))
+            .expect("HMI task did not spawn");
+    }
 
 
     loop {
@@ -720,7 +723,9 @@ async fn floating_espnow_task(
                         let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
                         hmi.acquiring_gps_capture = true;
                     }
-                    CAPTURE_MODE.store(true, Ordering::Relaxed);
+                    CAPTURE_MODE.store(true, Ordering::SeqCst);
+                    // Brief yield so the GPS task can see CAPTURE_MODE before we block on receive()
+                    Timer::after_millis(20).await;
 
                     let mut sent = 0u32;
                     for _ in 0..NUM_SAMPLES {
@@ -744,7 +749,7 @@ async fn floating_espnow_task(
                         sent
                     );
 
-                    CAPTURE_MODE.store(false, Ordering::Relaxed);
+                    CAPTURE_MODE.store(false, Ordering::SeqCst);
                     {
                         let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
                         hmi.acquiring_gps_capture = false;
@@ -768,14 +773,31 @@ pub async fn app_run_floating<B: BoardPeripherals>(spawner: embassy_executor::Sp
     let mut user_led = board.take_user_led();
     let mut neopixel = board.take_neopixel();
 
-    // Startup: brief orange flash
+    // Startup delay: show rainbow cycle on NeoPixel (same as regular sensor board)
     {
         use crate::hmi::Color;
-        neopixel
-            .set_color_with_brightness(Color::Orange, 30)
-            .await;
-        Timer::after_millis(500).await;
-        neopixel.clear().await;
+        let startup_duration = Duration::from_secs(3);
+        let step = Duration::from_millis(80);
+        let steps = (startup_duration.as_millis() / step.as_millis()) as u32;
+        fn wheel(pos: u8) -> (u8, u8, u8) {
+            if pos < 85 {
+                (255 - pos * 3, pos * 3, 0)
+            } else if pos < 170 {
+                let pos = pos - 85;
+                (0, 255 - pos * 3, pos * 3)
+            } else {
+                let pos = pos - 170;
+                (pos * 3, 0, 255 - pos * 3)
+            }
+        }
+        for i in 0..=steps {
+            let pos = ((i * 256 / (steps.max(1))) % 256) as u8;
+            let (r, g, b) = wheel(pos);
+            neopixel
+                .set_color_with_brightness(Color::Custom(r, g, b), 50)
+                .await;
+            Timer::after(step).await;
+        }
     }
 
     let _ = board.take_disp_spi_device();
@@ -797,7 +819,9 @@ pub async fn app_run_floating<B: BoardPeripherals>(spawner: embassy_executor::Sp
         .expect("GPS task did not spawn");
 
     let led_rate_hz = 1u32;
-    let neopixel_brightness = 10u8;
+    // Use higher NeoPixel brightness (50) so the single WS2812 is clearly visible; 10 is very dim
+    let neopixel_brightness = 50u8;
+    info!("[FLOATING] Spawning HMI floating task (user LED + NeoPixel)");
     spawner
         .spawn(start_hmi_floating_task(
             user_led,
@@ -819,8 +843,10 @@ async fn start_gps_task_floating(
 ) {
     gps2_uart = init_gps(gps2_uart).await;
     let on_data = |data: GpsData| {
-        if CAPTURE_MODE.load(Ordering::Relaxed) {
-            let _ = CAPTURE_CHANNEL.try_send(data);
+        if CAPTURE_MODE.load(Ordering::SeqCst) {
+            if CAPTURE_CHANNEL.try_send(data).is_ok() {
+                info!("[FLOATING] GPS sample pushed to capture channel (lat={:.6}, lon={:.6})", data.lat, data.lon);
+            }
         }
     };
     start_gps(gps2_uart, on_data).await;

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -29,7 +29,7 @@ use crate::hmi::{neopixel, start_hmi, start_hmi_floating};
 use crate::imu::start_imu;
 #[cfg(feature = "floating")]
 use crate::types::GpsData;
-#[cfg(feature = "floating")]
+#[cfg(any(feature = "floating", feature = "wifi"))]
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(all(feature = "wifi", feature = "usb"))]
 use crate::types::NodeId;
@@ -37,6 +37,7 @@ use crate::types::NodeId;
 use crate::usb::{
     MAX_USB_MESSAGE_SIZE, UsbCommand, UsbError, UsbSerial, UsbSerialRx, format_mac,
     serialize_forwarded_message,
+    serialize_track_capture_heartbeat,
 };
 
 /// Capacity of the sensor data channel
@@ -55,6 +56,10 @@ static SENSOR_CHANNEL: Channel<CriticalSectionRawMutex, SensorPayload, SENSOR_CH
 static CAPTURE_CHANNEL: Channel<CriticalSectionRawMutex, GpsData, 5> = Channel::new();
 #[cfg(feature = "floating")]
 static CAPTURE_MODE: AtomicBool = AtomicBool::new(false);
+
+/// When true, non-floating data nodes pause all transmissions (set by bridge TrackCaptureArmed broadcast)
+#[cfg(feature = "wifi")]
+static TRACK_CAPTURE_ARMED: AtomicBool = AtomicBool::new(false);
 
 pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mut board: B) {
     info!("app is starting execution now");
@@ -357,14 +362,23 @@ async fn espnow_transceiver_task(
 
         match embassy_time::with_timeout(timeout, transceiver.receive()).await {
             Ok(Ok(msg)) => {
-                if let SensorPayload::TimeSync(ts_data) = &msg.payload {
-                    crate::timebase::apply_sync(ts_data.session_time_us);
-                    info!(
-                        "[ESP-NOW RX] TimeSync applied: session={}us",
-                        ts_data.session_time_us
-                    );
-                } else {
-                    handle_received_message(&msg);
+                match &msg.payload {
+                    SensorPayload::TimeSync(ts_data) => {
+                        crate::timebase::apply_sync(ts_data.session_time_us);
+                        info!(
+                            "[ESP-NOW RX] TimeSync applied: session={}us",
+                            ts_data.session_time_us
+                        );
+                    }
+                    SensorPayload::TrackCaptureArmed => {
+                        TRACK_CAPTURE_ARMED.store(true, Ordering::SeqCst);
+                        info!("[ESP-NOW RX] Track capture armed - pausing transmissions");
+                    }
+                    SensorPayload::TrackCaptureEnded => {
+                        TRACK_CAPTURE_ARMED.store(false, Ordering::SeqCst);
+                        info!("[ESP-NOW RX] Track capture ended - resuming transmissions");
+                    }
+                    _ => handle_received_message(&msg),
                 }
             }
             Ok(Err(e)) => {
@@ -373,9 +387,11 @@ async fn espnow_transceiver_task(
             Err(_) => {}
         }
 
-        // Check if it's time to send heartbeat
+        // Check if it's time to send heartbeat (skip when track capture armed)
         if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
-            send_heartbeat(&mut transceiver).await;
+            if !TRACK_CAPTURE_ARMED.load(Ordering::SeqCst) {
+                send_heartbeat(&mut transceiver).await;
+            }
             last_heartbeat = Instant::now();
         }
     }
@@ -411,78 +427,81 @@ async fn espnow_sender_task(
             HEARTBEAT_INTERVAL - elapsed
         };
 
+        // Poll for incoming ESP-NOW (TimeSync, TrackCaptureArmed/Ended) with short timeout
+        match embassy_time::with_timeout(TIMESYNC_RX_POLL, transceiver.receive()).await {
+            Ok(Ok(msg)) => {
+                match &msg.payload {
+                    SensorPayload::TimeSync(ts_data) => {
+                        crate::timebase::apply_sync(ts_data.session_time_us);
+                        info!(
+                            "[ESP-NOW RX] TimeSync applied: session={}us",
+                            ts_data.session_time_us
+                        );
+                    }
+                    SensorPayload::TrackCaptureArmed => {
+                        TRACK_CAPTURE_ARMED.store(true, Ordering::SeqCst);
+                        info!("[ESP-NOW RX] Track capture armed - pausing transmissions");
+                    }
+                    SensorPayload::TrackCaptureEnded => {
+                        TRACK_CAPTURE_ARMED.store(false, Ordering::SeqCst);
+                        info!("[ESP-NOW RX] Track capture ended - resuming transmissions");
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Err(e)) => {
+                warn!("[ESP-NOW RX] Error during poll: {:?}", e);
+            }
+            Err(_) => {}
+        }
+
         // Try to receive sensor data from channel with timeout
         match embassy_time::with_timeout(timeout, SENSOR_CHANNEL.receive()).await {
             Ok(payload) => {
-                let timestamp_us = crate::timebase::synced_timestamp_us();
+                if TRACK_CAPTURE_ARMED.load(Ordering::SeqCst) {
+                    // Pause transmissions so floating node's GPS packets get through
+                    trace!("[ESP-NOW TX] Dropping {:?} (track capture armed)", payload.message_type());
+                } else {
+                    let timestamp_us = crate::timebase::synced_timestamp_us();
 
-                let result = match &payload {
-                    SensorPayload::Imu(data) => {
-                        info!(
-                            "[ESP-NOW TX] Sending IMU data, timestamp_us={}",
-                            timestamp_us
-                        );
-                        transceiver.send_imu(timestamp_us, data, &BROADCAST).await
-                    }
-                    SensorPayload::Gps(data) => {
-                        info!(
-                            "[ESP-NOW TX] Sending GPS data, timestamp_us={}",
-                            timestamp_us
-                        );
-                        transceiver.send_gps(timestamp_us, data, &BROADCAST).await
-                    }
-                    SensorPayload::Heartbeat(data) => {
-                        debug!("[ESP-NOW TX] Sending Heartbeat");
-                        transceiver
-                            .send_heartbeat(timestamp_us, data, &BROADCAST)
-                            .await
-                    }
-                    SensorPayload::TimeSync(_) => {
-                        // TimeSync payloads are not sent from data nodes
-                        Ok(())
-                    }
-                    SensorPayload::RequestGpsCapture => {
-                        // Only bridge sends this; data nodes ignore
-                        Ok(())
-                    }
-                };
+                    let result = match &payload {
+                        SensorPayload::Imu(data) => {
+                            info!(
+                                "[ESP-NOW TX] Sending IMU data, timestamp_us={}",
+                                timestamp_us
+                            );
+                            transceiver.send_imu(timestamp_us, data, &BROADCAST).await
+                        }
+                        SensorPayload::Gps(data) => {
+                            info!(
+                                "[ESP-NOW TX] Sending GPS data, timestamp_us={}",
+                                timestamp_us
+                            );
+                            transceiver.send_gps(timestamp_us, data, &BROADCAST).await
+                        }
+                        SensorPayload::Heartbeat(data) => {
+                            debug!("[ESP-NOW TX] Sending Heartbeat");
+                            transceiver
+                                .send_heartbeat(timestamp_us, data, &BROADCAST)
+                                .await
+                        }
+                        SensorPayload::TimeSync(_) => Ok(()),
+                        SensorPayload::RequestGpsCapture => Ok(()),
+                        SensorPayload::TrackCaptureArmed | SensorPayload::TrackCaptureEnded => Ok(()),
+                    };
 
-                match result {
-                    Ok(()) => {
-                        trace!("[ESP-NOW TX] Sent {:?}", payload.message_type());
-                    }
-                    Err(e) => {
+                    if let Err(e) = result {
                         warn!("[ESP-NOW TX] Send failed: {:?}", e);
                     }
                 }
             }
-            Err(_) => {
-                // Timeout - no sensor data, that's fine
-            }
-        }
-
-        // Poll for incoming ESP-NOW TimeSync from bridge (very short timeout)
-        match embassy_time::with_timeout(TIMESYNC_RX_POLL, transceiver.receive()).await {
-            Ok(Ok(msg)) => {
-                if let SensorPayload::TimeSync(ts_data) = &msg.payload {
-                    crate::timebase::apply_sync(ts_data.session_time_us);
-                    info!(
-                        "[ESP-NOW RX] TimeSync applied: session={}us",
-                        ts_data.session_time_us
-                    );
-                }
-                // Other message types received here are from other nodes; ignore
-            }
-            Ok(Err(e)) => {
-                warn!("[ESP-NOW RX] Error during TimeSync poll: {:?}", e);
-            }
-            Err(_) => {
-                // No incoming message -- expected
-            }
+            Err(_) => {}
         }
 
         if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
-            send_heartbeat(&mut transceiver).await;
+            if !TRACK_CAPTURE_ARMED.load(Ordering::SeqCst) {
+                send_heartbeat(&mut transceiver).await;
+            }
             last_heartbeat = Instant::now();
         }
     }
@@ -523,11 +542,69 @@ async fn espnow_bridge_task(
     /// Collecting 5 GPS from floating node for RequestFloatingGps response
     let mut floating_gps_remaining: u8 = 0;
     let mut floating_gps_mac: Option<[u8; 6]> = None;
+    /// Last time we received any USB command from Pi; when armed, 3 missed heartbeats (~2s) triggers auto-end.
+    let mut last_usb_from_pi: Option<embassy_time::Instant> = None;
+    const PI_HEARTBEAT_TIMEOUT: Duration = Duration::from_millis(2000);
+    /// When armed, send track-capture heartbeat to Pi every 500 ms so Pi can detect bridge alive.
+    let mut last_heartbeat_send: Option<embassy_time::Instant> = None;
+    const TRACK_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(500);
 
     loop {
+        // --- If armed and no USB from Pi for 3 heartbeats, auto-end track capture (e.g. Pi crashed) ---
+        {
+            let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+            if hmi.track_armed {
+                if let Some(ts) = last_usb_from_pi {
+                    if embassy_time::Instant::now().duration_since(ts) >= PI_HEARTBEAT_TIMEOUT {
+                        warn!("[BRIDGE] No USB from Pi for {} ms, auto-ending track capture", PI_HEARTBEAT_TIMEOUT.as_millis());
+                        hmi.track_armed = false;
+                        drop(hmi);
+                        last_usb_from_pi = None;
+                        last_heartbeat_send = None;
+                        let ts = crate::timebase::synced_timestamp_us();
+                        if let Err(e) = transceiver.send_track_capture_ended(ts, &BROADCAST).await {
+                            warn!("[BRIDGE] TrackCaptureEnded broadcast failed: {:?}", e);
+                        }
+                    } else {
+                        drop(hmi);
+                    }
+                } else {
+                    drop(hmi);
+                }
+            }
+        }
+
+        // --- When armed, send track-capture heartbeat to Pi so it knows bridge is alive ---
+        {
+            let hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+            if hmi.track_armed {
+                let now = embassy_time::Instant::now();
+                let should_send = last_heartbeat_send
+                    .map(|t| now.duration_since(t) >= TRACK_HEARTBEAT_INTERVAL)
+                    .unwrap_or(true);
+                drop(hmi);
+                if should_send {
+                    match serialize_track_capture_heartbeat(
+                        crate::timebase::synced_timestamp_us(),
+                        &mut msg_buffer,
+                    ) {
+                        Ok(len) => {
+                            if usb_serial.write_framed(&msg_buffer[..len]).await.is_ok() {
+                                last_heartbeat_send = Some(now);
+                            }
+                        }
+                        Err(_) => {}
+                    }
+                }
+            } else {
+                last_heartbeat_send = None;
+            }
+        }
+
         // --- Poll USB RX for commands from RPi (non-blocking) ---
         if let Some(ref mut rx) = usb_rx {
             while let Some(cmd) = rx.poll_command() {
+                last_usb_from_pi = Some(embassy_time::Instant::now());
                 match cmd {
                     UsbCommand::TimeSync { session_time_us } => {
                         timesync_count += 1;
@@ -563,11 +640,22 @@ async fn espnow_bridge_task(
                         info!("[BRIDGE] received arm (track capture armed)");
                         let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
                         hmi.track_armed = true;
+                        drop(hmi);
+                        let ts = crate::timebase::synced_timestamp_us();
+                        if let Err(e) = transceiver.send_track_capture_armed(ts, &BROADCAST).await {
+                            warn!("[BRIDGE] TrackCaptureArmed broadcast failed: {:?}", e);
+                        }
                     }
                     UsbCommand::EndTrack => {
                         info!("[BRIDGE] received end (track capture ended)");
+                        last_heartbeat_send = None;
                         let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
                         hmi.track_armed = false;
+                        drop(hmi);
+                        let ts = crate::timebase::synced_timestamp_us();
+                        if let Err(e) = transceiver.send_track_capture_ended(ts, &BROADCAST).await {
+                            warn!("[BRIDGE] TrackCaptureEnded broadcast failed: {:?}", e);
+                        }
                     }
                     UsbCommand::CaptureSuccess => {
                         info!("[BRIDGE] received capture success (show green 1s)");
@@ -1012,6 +1100,9 @@ fn handle_received_message(msg: &SensorMessage) {
         SensorPayload::RequestGpsCapture => {
             // Bridge -> floating; regular nodes ignore
             trace!("[ESP-NOW RX] RequestGpsCapture (ignored)");
+        }
+        SensorPayload::TrackCaptureArmed | SensorPayload::TrackCaptureEnded => {
+            // Handled in task to update TRACK_CAPTURE_ARMED
         }
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -24,9 +24,13 @@ use crate::aircomm::TimeSyncData;
 #[cfg(feature = "gps")]
 use crate::gps::{init_gps, start_gps};
 #[cfg(feature = "hmi")]
-use crate::hmi::{neopixel, start_hmi};
+use crate::hmi::{neopixel, start_hmi, start_hmi_floating};
 #[cfg(feature = "imu")]
 use crate::imu::start_imu;
+#[cfg(feature = "floating")]
+use crate::types::GpsData;
+#[cfg(feature = "floating")]
+use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(all(feature = "wifi", feature = "usb"))]
 use crate::types::NodeId;
 #[cfg(feature = "usb")]
@@ -45,6 +49,12 @@ const SENSOR_CHANNEL_CAPACITY: usize = 8;
 #[cfg(feature = "wifi")]
 static SENSOR_CHANNEL: Channel<CriticalSectionRawMutex, SensorPayload, SENSOR_CHANNEL_CAPACITY> =
     Channel::new();
+
+/// Floating node: channel for collecting 5 GPS samples when RequestGpsCapture is received
+#[cfg(feature = "floating")]
+static CAPTURE_CHANNEL: Channel<CriticalSectionRawMutex, GpsData, 5> = Channel::new();
+#[cfg(feature = "floating")]
+static CAPTURE_MODE: AtomicBool = AtomicBool::new(false);
 
 pub async fn app_run<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mut board: B) {
     info!("app is starting execution now");
@@ -428,6 +438,10 @@ async fn espnow_sender_task(
                         // TimeSync payloads are not sent from data nodes
                         Ok(())
                     }
+                    SensorPayload::RequestGpsCapture => {
+                        // Only bridge sends this; data nodes ignore
+                        Ok(())
+                    }
                 };
 
                 match result {
@@ -503,6 +517,9 @@ async fn espnow_bridge_task(
     let mut messages_forwarded: u32 = 0;
     let mut errors: u32 = 0;
     let mut timesync_count: u32 = 0;
+    /// Collecting 5 GPS from floating node for RequestFloatingGps response
+    let mut floating_gps_remaining: u8 = 0;
+    let mut floating_gps_mac: Option<[u8; 6]> = None;
 
     loop {
         // --- Poll USB RX for commands from RPi (non-blocking) ---
@@ -523,6 +540,16 @@ async fn espnow_bridge_task(
                                 "[BRIDGE] TimeSync #{}: session={}us, broadcast OK",
                                 timesync_count, session_time_us
                             );
+                        }
+                    }
+                    UsbCommand::RequestFloatingGps => {
+                        let ts = crate::timebase::synced_timestamp_us();
+                        if let Err(e) = transceiver.send_request_gps_capture(ts, &BROADCAST).await {
+                            warn!("[BRIDGE] RequestGpsCapture broadcast failed: {:?}", e);
+                        } else {
+                            info!("[BRIDGE] RequestFloatingGps: broadcast RequestGpsCapture, collecting 5 GPS");
+                            floating_gps_remaining = 5;
+                            floating_gps_mac = None;
                         }
                     }
                 }
@@ -590,38 +617,62 @@ async fn espnow_bridge_task(
                     .copied()
                     .unwrap_or_else(|| NodeId::new(CarPosition::Custom, 0));
 
-                // Serialize the message
-                match serialize_forwarded_message(
-                    &src_mac,
-                    &node_id,
-                    timestamp_us,
-                    &msg.payload,
-                    &mut msg_buffer,
-                ) {
-                    Ok(len) => {
-                        // Send via USB with COBS framing
-                        match usb_serial.write_framed(&msg_buffer[..len]).await {
-                            Ok(()) => {
-                                messages_forwarded += 1;
-                                trace!(
-                                    "[BRIDGE] Forwarded {:?} from {} ({}:{}) (total: {})",
-                                    msg.payload.message_type(),
-                                    format_mac(&src_mac),
-                                    node_id.position.as_str(),
-                                    node_id.instance,
-                                    messages_forwarded
-                                );
-                            }
-                            Err(UsbError::NotReady) => {}
-                            Err(e) => {
-                                errors += 1;
-                                warn!("[BRIDGE] USB write error: {:?}", e);
+                // When collecting floating GPS, only forward the 5 GPS from the floating node (first GPS sender)
+                let should_forward = if floating_gps_remaining > 0 {
+                    if let SensorPayload::Gps(_) = &msg.payload {
+                        let is_floating = floating_gps_mac.map(|m| m == src_mac).unwrap_or(true);
+                        if is_floating && floating_gps_mac.is_none() {
+                            floating_gps_mac = Some(src_mac);
+                        }
+                        is_floating
+                    } else {
+                        false
+                    }
+                } else {
+                    true
+                };
+
+                if should_forward {
+                    match serialize_forwarded_message(
+                        &src_mac,
+                        &node_id,
+                        timestamp_us,
+                        &msg.payload,
+                        &mut msg_buffer,
+                    ) {
+                        Ok(len) => {
+                            match usb_serial.write_framed(&msg_buffer[..len]).await {
+                                Ok(()) => {
+                                    messages_forwarded += 1;
+                                    if let SensorPayload::Gps(_) = &msg.payload {
+                                        if floating_gps_remaining > 0 {
+                                            floating_gps_remaining -= 1;
+                                            if floating_gps_remaining == 0 {
+                                                floating_gps_mac = None;
+                                                info!("[BRIDGE] Floating GPS: 5 samples forwarded to RPi");
+                                            }
+                                        }
+                                    }
+                                    trace!(
+                                        "[BRIDGE] Forwarded {:?} from {} ({}:{}) (total: {})",
+                                        msg.payload.message_type(),
+                                        format_mac(&src_mac),
+                                        node_id.position.as_str(),
+                                        node_id.instance,
+                                        messages_forwarded
+                                    );
+                                }
+                                Err(UsbError::NotReady) => {}
+                                Err(e) => {
+                                    errors += 1;
+                                    warn!("[BRIDGE] USB write error: {:?}", e);
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        errors += 1;
-                        warn!("[BRIDGE] Serialize error: {:?}", e);
+                        Err(e) => {
+                            errors += 1;
+                            warn!("[BRIDGE] Serialize error: {:?}", e);
+                        }
                     }
                 }
 
@@ -641,6 +692,149 @@ async fn espnow_bridge_task(
             }
         }
     }
+}
+
+// =============================================================================
+// Floating (GPS-only) node: wait for RequestGpsCapture, reply with 5 GPS samples
+// =============================================================================
+
+#[cfg(all(feature = "floating", feature = "wifi"))]
+#[embassy_executor::task]
+async fn floating_espnow_task(
+    mut transceiver: AirCommTransceiver<'static>,
+    _wifi_controller: esp_radio::wifi::WifiController<'static>,
+) {
+    use crate::aircomm::SensorPayload;
+
+    info!("[FLOATING] ESP-NOW task started (wait for RequestGpsCapture, reply with 5 GPS)");
+
+    const COLLECT_TIMEOUT: Duration = Duration::from_millis(800);
+    const NUM_SAMPLES: u32 = 5;
+
+    loop {
+        match transceiver.receive().await {
+            Ok(msg) => {
+                if let SensorPayload::RequestGpsCapture = msg.payload {
+                    info!("[FLOATING] RequestGpsCapture received, collecting 5 GPS samples");
+                    {
+                        let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+                        hmi.acquiring_gps_capture = true;
+                    }
+                    CAPTURE_MODE.store(true, Ordering::Relaxed);
+
+                    let mut sent = 0u32;
+                    for _ in 0..NUM_SAMPLES {
+                        match embassy_time::with_timeout(
+                            COLLECT_TIMEOUT,
+                            CAPTURE_CHANNEL.receive(),
+                        )
+                        .await
+                        {
+                            Ok(gps) => {
+                                let ts = crate::timebase::synced_timestamp_us();
+                                if transceiver.send_gps(ts, &gps, &BROADCAST).await.is_ok() {
+                                    sent += 1;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    info!(
+                        "[FLOATING] Sent {} GPS samples in response to capture request",
+                        sent
+                    );
+
+                    CAPTURE_MODE.store(false, Ordering::Relaxed);
+                    {
+                        let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+                        hmi.acquiring_gps_capture = false;
+                    }
+                }
+                // Ignore other message types (TimeSync, Heartbeat, etc.)
+            }
+            Err(e) => {
+                warn!("[FLOATING] Receive error: {:?}", e);
+            }
+        }
+    }
+}
+
+#[cfg(feature = "floating")]
+pub async fn app_run_floating<B: BoardPeripherals>(spawner: embassy_executor::Spawner, mut board: B) {
+    info!("[FLOATING] app starting (GPS-only, wait for RequestGpsCapture)");
+
+    crate::timebase::set_program_start();
+
+    let mut user_led = board.take_user_led();
+    let mut neopixel = board.take_neopixel();
+
+    // Startup: brief orange flash
+    {
+        use crate::hmi::Color;
+        neopixel
+            .set_color_with_brightness(Color::Orange, 30)
+            .await;
+        Timer::after_millis(500).await;
+        neopixel.clear().await;
+    }
+
+    let _ = board.take_disp_spi_device();
+    let gps2_uart = board.take_gps2_uart();
+
+    if let Some(wifi) = board.take_wifi() {
+        match AirCommTransceiver::new(wifi.esp_now) {
+            Ok(transceiver) => {
+                spawner
+                    .spawn(floating_espnow_task(transceiver, wifi.controller))
+                    .expect("floating ESP-NOW task did not spawn");
+            }
+            Err(e) => warn!("[FLOATING] AirComm init failed: {:?}", e),
+        }
+    }
+
+    spawner
+        .spawn(start_gps_task_floating(gps2_uart))
+        .expect("GPS task did not spawn");
+
+    let led_rate_hz = 1u32;
+    let neopixel_brightness = 10u8;
+    spawner
+        .spawn(start_hmi_floating_task(
+            user_led,
+            neopixel,
+            led_rate_hz,
+            neopixel_brightness,
+        ))
+        .expect("HMI floating task did not spawn");
+
+    loop {
+        Timer::after_secs(1).await;
+    }
+}
+
+#[cfg(feature = "floating")]
+#[embassy_executor::task]
+async fn start_gps_task_floating(
+    mut gps2_uart: esp_hal::uart::Uart<'static, esp_hal::Async>,
+) {
+    gps2_uart = init_gps(gps2_uart).await;
+    let on_data = |data: GpsData| {
+        if CAPTURE_MODE.load(Ordering::Relaxed) {
+            let _ = CAPTURE_CHANNEL.try_send(data);
+        }
+    };
+    start_gps(gps2_uart, on_data).await;
+}
+
+#[cfg(feature = "floating")]
+#[embassy_executor::task]
+async fn start_hmi_floating_task(
+    user_led: esp_hal::gpio::Output<'static>,
+    neopixel: neopixel::NeoPixel<'static>,
+    led_rate_hz: u32,
+    neopixel_brightness: u8,
+) {
+    start_hmi_floating(user_led, led_rate_hz, neopixel, neopixel_brightness).await;
 }
 
 // =============================================================================
@@ -707,6 +901,10 @@ fn handle_received_message(msg: &SensorMessage) {
                 "[ESP-NOW RX] TimeSync from {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} | session={}us",
                 src[0], src[1], src[2], src[3], src[4], src[5], data.session_time_us
             );
+        }
+        SensorPayload::RequestGpsCapture => {
+            // Bridge -> floating; regular nodes ignore
+            trace!("[ESP-NOW RX] RequestGpsCapture (ignored)");
         }
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/app.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/app.rs
@@ -539,21 +539,49 @@ async fn espnow_bridge_task(
                         if let Err(e) = transceiver.send_timesync(ts, &data, &BROADCAST).await {
                             warn!("[BRIDGE] TimeSync broadcast failed: {:?}", e);
                         } else {
-                            info!(
+                            trace!(
                                 "[BRIDGE] TimeSync #{}: session={}us, broadcast OK",
                                 timesync_count, session_time_us
                             );
                         }
                     }
                     UsbCommand::RequestFloatingGps => {
+                        info!("[BRIDGE] received take (RequestFloatingGps)");
+                        {
+                            let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+                            hmi.capture_led_phase = crate::hmi::state::CAPTURE_PHASE_REQUEST_SENT;
+                        }
                         let ts = crate::timebase::synced_timestamp_us();
                         if let Err(e) = transceiver.send_request_gps_capture(ts, &BROADCAST).await {
                             warn!("[BRIDGE] RequestGpsCapture broadcast failed: {:?}", e);
                         } else {
-                            info!("[BRIDGE] RequestFloatingGps: broadcast RequestGpsCapture, collecting 5 GPS");
                             floating_gps_remaining = 5;
                             floating_gps_mac = None;
                         }
+                    }
+                    UsbCommand::ArmTrack => {
+                        info!("[BRIDGE] received arm (track capture armed)");
+                        let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+                        hmi.track_armed = true;
+                    }
+                    UsbCommand::EndTrack => {
+                        info!("[BRIDGE] received end (track capture ended)");
+                        let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+                        hmi.track_armed = false;
+                    }
+                    UsbCommand::CaptureSuccess => {
+                        info!("[BRIDGE] received capture success (show green 1s)");
+                        let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+                        hmi.capture_led_phase = crate::hmi::state::CAPTURE_PHASE_SUCCESS;
+                        hmi.capture_phase_deadline =
+                            Some(embassy_time::Instant::now() + Duration::from_secs(1));
+                    }
+                    UsbCommand::CaptureTimeout => {
+                        info!("[BRIDGE] received capture timeout (show rainbow 1s)");
+                        let mut hmi = crate::hmi::state::HMI_STATE.0.lock().await;
+                        hmi.capture_led_phase = crate::hmi::state::CAPTURE_PHASE_TIMEOUT;
+                        hmi.capture_phase_deadline =
+                            Some(embassy_time::Instant::now() + Duration::from_secs(1));
                     }
                 }
             }
@@ -652,7 +680,7 @@ async fn espnow_bridge_task(
                                             floating_gps_remaining -= 1;
                                             if floating_gps_remaining == 0 {
                                                 floating_gps_mac = None;
-                                                info!("[BRIDGE] Floating GPS: 5 samples forwarded to RPi");
+                                                info!("[BRIDGE] received responses (5 GPS forwarded to RPi)");
                                             }
                                         }
                                     }
@@ -724,8 +752,8 @@ async fn floating_espnow_task(
                         hmi.acquiring_gps_capture = true;
                     }
                     CAPTURE_MODE.store(true, Ordering::SeqCst);
-                    // Brief yield so the GPS task can see CAPTURE_MODE before we block on receive()
-                    Timer::after_millis(20).await;
+                    // Give GPS task time to see CAPTURE_MODE and for next GGA to arrive (10 Hz = 100 ms period)
+                    Timer::after_millis(150).await;
 
                     let mut sent = 0u32;
                     for _ in 0..NUM_SAMPLES {
@@ -748,6 +776,18 @@ async fn floating_espnow_task(
                         "[FLOATING] Sent {} GPS samples in response to capture request",
                         sent
                     );
+                    if sent == 0 {
+                        warn!(
+                            "[FLOATING] No GPS samples: ensure the receiver has a fix (outdoor, antenna) and outputs GGA with position"
+                        );
+                        crate::gps::with_last_raw_gga(|opt| {
+                            if let Some(raw) = opt {
+                                info!("[FLOATING] Last parsed GGA (raw): {}", raw);
+                            } else {
+                                info!("[FLOATING] No GGA sentence parsed yet (no fix or no NMEA?)");
+                            }
+                        });
+                    }
 
                     CAPTURE_MODE.store(false, Ordering::SeqCst);
                     {
@@ -801,7 +841,10 @@ pub async fn app_run_floating<B: BoardPeripherals>(spawner: embassy_executor::Sp
     }
 
     let _ = board.take_disp_spi_device();
-    let gps2_uart = board.take_gps2_uart();
+    let gps2_uart = match board.take_gps2_uart_blocking() {
+        Some(blocking) => crate::gps::detect_gps_baud_and_init(blocking).await,
+        None => init_gps(board.take_gps2_uart()).await,
+    };
 
     if let Some(wifi) = board.take_wifi() {
         match AirCommTransceiver::new(wifi.esp_now) {
@@ -831,8 +874,46 @@ pub async fn app_run_floating<B: BoardPeripherals>(spawner: embassy_executor::Sp
         ))
         .expect("HMI floating task did not spawn");
 
+    spawner
+        .spawn(gps_stale_watchdog_task())
+        .expect("GPS stale watchdog task did not spawn");
+
     loop {
         Timer::after_secs(1).await;
+    }
+}
+
+/// Warns or errors if no successfully parsed GPS (GGA) in the last 1s or 5s.
+#[cfg(feature = "floating")]
+#[embassy_executor::task]
+async fn gps_stale_watchdog_task() {
+    const WARN_THRESHOLD: Duration = Duration::from_secs(1);
+    const ERROR_THRESHOLD: Duration = Duration::from_secs(5);
+
+    loop {
+        Timer::after_secs(1).await;
+        let state = crate::hmi::state::HMI_STATE.0.lock().await;
+        let now = embassy_time::Instant::now();
+        let stale = match state.last_gps_timestamp {
+            Some(ts) => now.duration_since(ts),
+            None => {
+                drop(state);
+                warn!("[FLOATING] No successfully parsed GPS (GGA) message yet");
+                continue;
+            }
+        };
+        drop(state);
+        if stale >= ERROR_THRESHOLD {
+            error!(
+                "[FLOATING] No GPS (GGA) parsed for {}s - check antenna, fix, and NMEA output",
+                stale.as_secs()
+            );
+        } else if stale >= WARN_THRESHOLD {
+            warn!(
+                "[FLOATING] No GPS (GGA) parsed in the last {}s",
+                stale.as_secs()
+            );
+        }
     }
 }
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_floating.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_floating.rs
@@ -41,7 +41,7 @@ pub struct FloatingBoard {
     pub user_led: Option<esp_hal::gpio::Output<'static>>,
     pub neopixel: Option<neopixel::NeoPixel<'static>>,
     pub disp_spi: Option<SharedSpiDevice>,
-    pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Async>>,
+    pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Blocking>>,
     pub wifi: Option<WifiResources>,
 }
 
@@ -62,12 +62,12 @@ impl FloatingBoard {
             .into_async();
         let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO18);
 
-        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(460800);
+        // Start at 9600 for baud detection; do not into_async() until after detect_gps_baud_and_init
+        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(9600);
         let gps2_uart = esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
             .unwrap()
             .with_rx(peripherals.GPIO23)
-            .with_tx(peripherals.GPIO22)
-            .into_async();
+            .with_tx(peripherals.GPIO22);
 
         let spi_config = esp_hal::spi::master::Config::default()
             .with_frequency(esp_hal::time::Rate::from_khz(100))
@@ -126,7 +126,11 @@ impl BoardPeripherals for FloatingBoard {
     }
 
     fn take_gps2_uart(&mut self) -> esp_hal::uart::Uart<'static, esp_hal::Async> {
-        self.gps2_uart.take().expect("gps2_uart already taken")
+        panic!("floating board: use take_gps2_uart_blocking() and detect_gps_baud_and_init");
+    }
+
+    fn take_gps2_uart_blocking(&mut self) -> Option<esp_hal::uart::Uart<'static, esp_hal::Blocking>> {
+        self.gps2_uart.take()
     }
 
     fn take_wifi(&mut self) -> Option<WifiResources> {

--- a/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_floating.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/bin/sensorboard_floating.rs
@@ -1,0 +1,155 @@
+#![no_std]
+#![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types"
+)]
+
+use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
+use embassy_sync::mutex::Mutex;
+use log::info;
+use sensor_board_rev1_test::hmi::neopixel;
+use sensor_board_rev1_test::{app::app_run_floating, BoardPeripherals, WifiResources};
+use sensor_board_rev1_test::{SharedSpiBus, SharedSpiDevice};
+use static_cell::StaticCell;
+
+use esp_alloc as _;
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+fn init_heap() {
+    const HEAP_SIZE: usize = 128 * 1024;
+    static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+    unsafe {
+        esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
+            &HEAP[0] as *const u8 as *mut u8,
+            HEAP_SIZE,
+            esp_alloc::MemoryCapability::Internal.into(),
+        ));
+    }
+}
+
+static SPI_BUS: StaticCell<SharedSpiBus> = StaticCell::new();
+
+/// Board for floating (GPS-only) node: same rev1 hardware, no IMU.
+pub struct FloatingBoard {
+    pub user_led: Option<esp_hal::gpio::Output<'static>>,
+    pub neopixel: Option<neopixel::NeoPixel<'static>>,
+    pub disp_spi: Option<SharedSpiDevice>,
+    pub gps2_uart: Option<esp_hal::uart::Uart<'static, esp_hal::Async>>,
+    pub wifi: Option<WifiResources>,
+}
+
+impl FloatingBoard {
+    pub fn from_peripherals(peripherals: esp_hal::peripherals::Peripherals) -> Self {
+        let timg0 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0);
+        let software_interrupt =
+            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+        esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
+
+        let user_led = esp_hal::gpio::Output::new(
+            peripherals.GPIO19,
+            esp_hal::gpio::Level::High,
+            esp_hal::gpio::OutputConfig::default(),
+        );
+        let rmt = esp_hal::rmt::Rmt::new(peripherals.RMT, esp_hal::time::Rate::from_mhz(80))
+            .unwrap()
+            .into_async();
+        let neopixel = neopixel::NeoPixel::new(rmt.channel0, peripherals.GPIO18);
+
+        let gps2_uart_config = esp_hal::uart::Config::default().with_baudrate(460800);
+        let gps2_uart = esp_hal::uart::Uart::new(peripherals.UART1, gps2_uart_config)
+            .unwrap()
+            .with_rx(peripherals.GPIO23)
+            .with_tx(peripherals.GPIO22)
+            .into_async();
+
+        let spi_config = esp_hal::spi::master::Config::default()
+            .with_frequency(esp_hal::time::Rate::from_khz(100))
+            .with_mode(esp_hal::spi::Mode::_0);
+        let spi2 = esp_hal::spi::master::Spi::new(peripherals.SPI2, spi_config)
+            .unwrap()
+            .with_sck(peripherals.GPIO6)
+            .with_mosi(peripherals.GPIO7)
+            .with_miso(peripherals.GPIO0)
+            .into_async();
+        let spi_bus = SPI_BUS.init(Mutex::new(spi2));
+        let disp_spi2_cs = esp_hal::gpio::Output::new(
+            peripherals.GPIO10,
+            esp_hal::gpio::Level::High,
+            esp_hal::gpio::OutputConfig::default(),
+        );
+        let disp_spi_device = SpiDevice::new(spi_bus, disp_spi2_cs);
+
+        let wifi = match esp_radio::wifi::new(peripherals.WIFI, esp_radio::wifi::Config::default()) {
+            Ok((mut wifi_controller, interfaces)) => {
+                if wifi_controller.set_mode(esp_radio::wifi::WifiMode::Station).is_ok()
+                    && wifi_controller.start().is_ok()
+                {
+                    Some(WifiResources {
+                        controller: wifi_controller,
+                        esp_now: interfaces.esp_now,
+                    })
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        };
+
+        Self {
+            user_led: Some(user_led),
+            neopixel: Some(neopixel),
+            disp_spi: Some(disp_spi_device),
+            gps2_uart: Some(gps2_uart),
+            wifi,
+        }
+    }
+}
+
+impl BoardPeripherals for FloatingBoard {
+    fn take_user_led(&mut self) -> esp_hal::gpio::Output<'static> {
+        self.user_led.take().expect("user LED already taken")
+    }
+
+    fn take_neopixel(&mut self) -> neopixel::NeoPixel<'static> {
+        self.neopixel.take().expect("NeoPixel already taken")
+    }
+
+    fn take_disp_spi_device(&mut self) -> SharedSpiDevice {
+        self.disp_spi.take().expect("DisplaySPI device already taken")
+    }
+
+    fn take_gps2_uart(&mut self) -> esp_hal::uart::Uart<'static, esp_hal::Async> {
+        self.gps2_uart.take().expect("gps2_uart already taken")
+    }
+
+    fn take_wifi(&mut self) -> Option<WifiResources> {
+        self.wifi.take()
+    }
+
+    fn espnow_mode(&self) -> sensor_board_rev1_test::EspNowMode {
+        sensor_board_rev1_test::EspNowMode::Transceiver
+    }
+}
+
+#[esp_rtos::main]
+async fn main(spawner: embassy_executor::Spawner) {
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+    init_heap();
+
+    let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
+    let peripherals = esp_hal::init(config);
+
+    info!("sensorboard_floating: GPS-only node, waiting for RequestGpsCapture");
+    let board = FloatingBoard::from_peripherals(peripherals);
+    app_run_floating(spawner, board).await;
+    loop {
+        embassy_time::Timer::after_secs(1).await
+    }
+}

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -1,5 +1,7 @@
 use core::fmt::Write;
 use esp_hal::Async;
+#[cfg(feature = "floating")]
+use esp_hal::uart::Config;
 use esp_hal::uart::Uart;
 use heapless::String;
 #[cfg(feature = "set_gps_10hz")]
@@ -11,6 +13,51 @@ use crate::types::{GpsData, GpsTime};
 use embassy_time::Instant;
 
 const NMEA_0183_MAX_LENGTH: usize = 83;
+const LAST_RAW_GGA_CAP: usize = 84;
+
+/// Last successfully parsed GGA sentence (raw NMEA), for diagnostic logging when capture gets 0 samples.
+/// Stored as bytes to avoid Rust 2024 static_mut_refs; copied out byte-wise in with_last_raw_gga.
+static mut LAST_RAW_GGA_BUF: [u8; LAST_RAW_GGA_CAP] = [0; LAST_RAW_GGA_CAP];
+static mut LAST_RAW_GGA_LEN: u8 = 0;
+
+/// Store the raw GGA sentence (call when a GGA is parsed). Truncates to fit.
+pub fn set_last_raw_gga(sentence: &str) {
+    let end = sentence
+        .char_indices()
+        .nth(NMEA_0183_MAX_LENGTH)
+        .map(|(i, _)| i)
+        .unwrap_or(sentence.len());
+    let trunc = &sentence[..end.min(sentence.len())];
+    let bytes = trunc.as_bytes();
+    let len = bytes.len().min(LAST_RAW_GGA_CAP) as u8;
+    critical_section::with(|_| unsafe {
+        for (i, &b) in bytes.iter().take(LAST_RAW_GGA_CAP).enumerate() {
+            LAST_RAW_GGA_BUF[i] = b;
+        }
+        LAST_RAW_GGA_LEN = len;
+    });
+}
+
+/// Run a closure with the last raw GGA sentence (if any), for logging.
+pub fn with_last_raw_gga<F, R>(f: F) -> R
+where
+    F: FnOnce(Option<&str>) -> R,
+{
+    let mut local_buf = [0u8; LAST_RAW_GGA_CAP];
+    let len = critical_section::with(|_| unsafe {
+        let n = LAST_RAW_GGA_LEN as usize;
+        for i in 0..n {
+            local_buf[i] = LAST_RAW_GGA_BUF[i];
+        }
+        n
+    });
+    let opt_str = if len > 0 {
+        core::str::from_utf8(&local_buf[..len]).ok()
+    } else {
+        None
+    };
+    f(opt_str)
+}
 const MAX_SENTENCE_LENGTH: usize = NMEA_0183_MAX_LENGTH + 2; // give ourselves buffer for newlines
 const NUM_NMEA_SENTENCES: usize = 5; // RMC, VTG, GGA
 const CHUNK_BUFF_SIZE: usize = MAX_SENTENCE_LENGTH * (NUM_NMEA_SENTENCES + 1); // buffer
@@ -93,6 +140,103 @@ async fn send_ubx_packet(
         Ok(_) => info!("UBX {} sent.", name),
         Err(e) => error!("Failed to send UBX {}: {:?}", name, e),
     }
+}
+
+/// Baud rates to try when auto-detecting GPS (before sending any configuration).
+#[cfg(feature = "floating")]
+const DETECT_BAUD_RATES: &[u32] = &[9600, 38400, 115200, 460800];
+#[cfg(feature = "floating")]
+const DETECT_READ_MS: u64 = 700;
+#[cfg(feature = "floating")]
+const DETECT_CHUNK_MS: u64 = 50;
+
+/// Try common baud rates, read NMEA without sending config, and return (uart at detected baud, detected baud).
+/// Logs "Trying baud X...", "Could not parse..." or "Parsed GG* ... NUM SATS: N".
+#[cfg(feature = "floating")]
+pub async fn detect_gps_baud_and_init(
+    mut uart: Uart<'static, esp_hal::Blocking>,
+) -> Uart<'static, Async> {
+    use embassy_time::Timer;
+
+    let mut parser = nmea_parser::NmeaParser::new();
+    let mut line_buf: heapless::String<{ NMEA_0183_MAX_LENGTH + 2 }> = heapless::String::new();
+    let mut read_buf = [0u8; 128];
+    let mut detected_baud: Option<u32> = None;
+
+    for &baud in DETECT_BAUD_RATES {
+        info!("Trying baud {}...", baud);
+        let config = Config::default().with_baudrate(baud);
+        if uart.apply_config(&config).is_err() {
+            warn!("Could not set baud {} on UART", baud);
+            continue;
+        }
+        // Drain any stale bytes from previous baud
+        loop {
+            match uart.read_buffered(&mut read_buf) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        Timer::after_millis(DETECT_CHUNK_MS).await;
+
+        let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_millis(DETECT_READ_MS);
+        let mut got_gga = false;
+        let mut num_sats: Option<u8> = None;
+
+        while embassy_time::Instant::now() < deadline {
+            match uart.read_buffered(&mut read_buf) {
+                Ok(n) if n > 0 => {
+                    for &b in &read_buf[..n] {
+                        if b == b'\n' || b == b'\r' {
+                            if !line_buf.is_empty() {
+                                let sentence = line_buf.as_str().trim();
+                                if sentence.len() >= 7 && (sentence.starts_with("$GPGGA") || sentence.starts_with("$GNGGA")) {
+                                    match parser.parse_sentence(sentence) {
+                                        Ok(nmea_parser::ParsedMessage::Gga(gga)) => {
+                                            let sats = gga.satellite_count.unwrap_or(0);
+                                            num_sats = Some(sats);
+                                            got_gga = true;
+                                            info!(
+                                                "Parsed {} ... NUM SATS: {}",
+                                                &sentence[..sentence.len().min(20)],
+                                                sats
+                                            );
+                                            break;
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                                line_buf.clear();
+                            }
+                        } else if line_buf.push(b as char).is_err() {
+                            line_buf.clear();
+                        }
+                    }
+                    if got_gga {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            Timer::after_millis(10).await;
+        }
+
+        if got_gga {
+            detected_baud = Some(baud);
+            info!("GPS baud detected: {} (NUM SATS: {:?})", baud, num_sats);
+            break;
+        }
+        info!("Could not parse GGA at baud {} (no valid $GP* / $GN* GGA in {} ms)", baud, DETECT_READ_MS);
+    }
+
+    let baud = detected_baud.unwrap_or(9600);
+    if detected_baud.is_none() {
+        warn!("Using default baud {} (no GGA seen at any tried rate)", baud);
+    }
+
+    let uart_async = uart.into_async();
+    init_gps(uart_async).await
 }
 
 pub async fn init_gps(mut gps2_uart: Uart<'static, Async>) -> esp_hal::uart::Uart<'static, Async> {
@@ -261,12 +405,13 @@ where
                 match parser.parse_sentence(sentence) {
                     Ok(parsed_data) => match parsed_data {
                         nmea_parser::ParsedMessage::Gga(gga) => {
+                            set_last_raw_gga(sentence);
                             let elapsed_s = crate::timebase::elapsed_seconds();
                             let has_fix = gga.latitude.is_some() && gga.longitude.is_some();
                             let sat_count = gga.satellite_count.unwrap_or(0);
 
                             if has_fix {
-                                info!(
+                                debug!(
                                     "t={:.3}s GPGGA ✓ VALID FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
                                     elapsed_s,
                                     gga.latitude.unwrap_or(0.0),
@@ -314,7 +459,7 @@ where
                         nmea_parser::ParsedMessage::Rmc(rmc) => {
                             if let Some(time) = rmc.timestamp {
                                 let elapsed_s = crate::timebase::elapsed_seconds();
-                                info!("t={:.3}s GPS rmc time is: {}", elapsed_s, time);
+                                debug!("t={:.3}s GPS rmc time is: {}", elapsed_s, time);
 
                                 // Update cached time from RMC
                                 last_time = Some(GpsTime {
@@ -347,7 +492,7 @@ where
                             let speed_kph = vtg.sog_kph.unwrap_or(0.0);
                             let course = vtg.cog_true.unwrap_or(0.0);
                             let elapsed_s = crate::timebase::elapsed_seconds();
-                            info!(
+                            debug!(
                                 "t={:.3}s GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
                                 elapsed_s, speed_knots, speed_kph, course
                             );

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -421,7 +421,7 @@ where
                             let sat_count = gga.satellite_count.unwrap_or(0);
 
                             if has_fix {
-                                debug!(
+                                info!(
                                     "t={:.3}s GPGGA ✓ VALID FIX: Lat={}, Lon={}, HDOP={}, SATS={}",
                                     elapsed_s,
                                     gga.latitude.unwrap_or(0.0),
@@ -469,7 +469,7 @@ where
                         nmea_parser::ParsedMessage::Rmc(rmc) => {
                             if let Some(time) = rmc.timestamp {
                                 let elapsed_s = crate::timebase::elapsed_seconds();
-                                debug!("t={:.3}s GPS rmc time is: {}", elapsed_s, time);
+                                info!("t={:.3}s GPS rmc time is: {}", elapsed_s, time);
 
                                 // Update cached time from RMC
                                 last_time = Some(GpsTime {
@@ -502,7 +502,7 @@ where
                             let speed_kph = vtg.sog_kph.unwrap_or(0.0);
                             let course = vtg.cog_true.unwrap_or(0.0);
                             let elapsed_s = crate::timebase::elapsed_seconds();
-                            debug!(
+                            info!(
                                 "t={:.3}s GNVTG VELOCITY: Speed={:.2} knots ({:.2} km/h); Heading: {}",
                                 elapsed_s, speed_knots, speed_kph, course
                             );

--- a/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/gps/mod.rs
@@ -145,10 +145,14 @@ async fn send_ubx_packet(
 /// Baud rates to try when auto-detecting GPS (before sending any configuration).
 #[cfg(feature = "floating")]
 const DETECT_BAUD_RATES: &[u32] = &[9600, 38400, 115200, 460800];
+/// Time to listen at each baud rate for a GGA sentence (GPS may be slow after power-up).
 #[cfg(feature = "floating")]
-const DETECT_READ_MS: u64 = 700;
+const DETECT_READ_MS: u64 = 1200;
 #[cfg(feature = "floating")]
 const DETECT_CHUNK_MS: u64 = 50;
+/// Delay before first baud try so the GPS module has time to power up and start sending NMEA.
+#[cfg(feature = "floating")]
+const DETECT_STARTUP_DELAY_MS: u64 = 2500;
 
 /// Try common baud rates, read NMEA without sending config, and return (uart at detected baud, detected baud).
 /// Logs "Trying baud X...", "Could not parse..." or "Parsed GG* ... NUM SATS: N".
@@ -157,6 +161,12 @@ pub async fn detect_gps_baud_and_init(
     mut uart: Uart<'static, esp_hal::Blocking>,
 ) -> Uart<'static, Async> {
     use embassy_time::Timer;
+
+    info!(
+        "GPS baud detection: waiting {} ms for module to start sending...",
+        DETECT_STARTUP_DELAY_MS
+    );
+    Timer::after_millis(DETECT_STARTUP_DELAY_MS).await;
 
     let mut parser = nmea_parser::NmeaParser::new();
     let mut line_buf: heapless::String<{ NMEA_0183_MAX_LENGTH + 2 }> = heapless::String::new();

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -8,11 +8,22 @@ use esp_hal::gpio::Output;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
-use crate::hmi::state::HmiState;
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-use embassy_sync::mutex::Mutex;
+use crate::hmi::state::{CAPTURE_PHASE_IDLE, CAPTURE_PHASE_REQUEST_SENT, CAPTURE_PHASE_SUCCESS, CAPTURE_PHASE_TIMEOUT};
 use embassy_time::{Duration, Instant, Timer};
 pub use neopixel::{Color, NeoPixel};
+
+/// Rainbow wheel: position 0..255 -> (r, g, b)
+fn wheel(pos: u8) -> (u8, u8, u8) {
+    if pos < 85 {
+        (255 - pos * 3, pos * 3, 0)
+    } else if pos < 170 {
+        let pos = pos - 85;
+        (0, 255 - pos * 3, pos * 3)
+    } else {
+        let pos = pos - 170;
+        (pos * 3, 0, 255 - pos * 3)
+    }
+}
 
 pub async fn start_hmi(
     mut user_led: Output<'static>,
@@ -21,10 +32,8 @@ pub async fn start_hmi(
     neopixel_brightness: u8,
 ) {
     info!("[HMI] Task started (LED + NeoPixel, {} Hz)", led_rate_hz);
-    let period = Duration::from_hz(led_rate_hz as u64);
 
     let mut led_on = false;
-
     let mut slow_blink_on = false;
 
     loop {
@@ -40,63 +49,117 @@ pub async fn start_hmi(
         led_on = !led_on;
 
         // Read HMI state to decide NeoPixel behaviour
-        let state = crate::hmi::state::HMI_STATE.0.lock().await;
+        let mut state = crate::hmi::state::HMI_STATE.0.lock().await;
         let now = Instant::now();
 
-        // Determine IMU age and color
-        let color = if let Some(last_imu) = state.last_imu_timestamp {
-            let age = now.duration_since(last_imu);
-            if age.as_millis() <= 20 {
-                Color::Green
-            } else if age.as_secs() <= 10 {
-                Color::Blue
-            } else {
-                Color::Red
+        // Clear capture phase when deadline passed
+        if state.capture_led_phase == CAPTURE_PHASE_SUCCESS || state.capture_led_phase == CAPTURE_PHASE_TIMEOUT {
+            if let Some(deadline) = state.capture_phase_deadline {
+                if now >= deadline {
+                    state.capture_led_phase = CAPTURE_PHASE_IDLE;
+                    state.capture_phase_deadline = None;
+                }
             }
-        } else {
-            Color::Red
-        };
+        }
 
-        // Determine GPS connection vs fix status
-        let gps_rx_recent = state
-            .last_gps_rx_timestamp
-            .map(|ts| now.duration_since(ts).as_secs() <= 3)
-            .unwrap_or(false);
+        // Loop period: 4x when armed; when breathing (GPS fix) use 20 Hz for smooth animation; else base rate
         let gps_fix_recent = state.gps_fix
             && state
                 .last_gps_timestamp
                 .map(|ts| now.duration_since(ts).as_secs() <= 3)
                 .unwrap_or(false);
-        drop(state);
-
-        if gps_fix_recent {
-            // GPS fix -> solid
-            neopixel
-                .set_color_with_brightness(color, neopixel_brightness)
-                .await;
-        } else if gps_rx_recent {
-            // GPS connected, no fix -> fast double pulse (0.1s on, 0.1s off, 0.1s on, 0.7s off)
-            neopixel
-                .set_color_with_brightness(color, neopixel_brightness)
-                .await;
-            Timer::after_millis(100).await;
-            neopixel.clear().await;
-            Timer::after_millis(100).await;
-            neopixel
-                .set_color_with_brightness(color, neopixel_brightness)
-                .await;
-            Timer::after_millis(100).await;
-            neopixel.clear().await;
-            Timer::after_millis(700).await;
+        let period = if state.capture_led_phase != CAPTURE_PHASE_IDLE {
+            Duration::from_millis(50) // Fast tick so we clear phase when deadline passes
+        } else if state.track_armed {
+            Duration::from_hz((led_rate_hz * 4) as u64)
+        } else if gps_fix_recent {
+            Duration::from_millis(25) // 40 Hz for smooth breathing
         } else {
-            // No GPS data -> slow blink
-            slow_blink_on = !slow_blink_on;
-            if slow_blink_on {
+            Duration::from_hz(led_rate_hz as u64)
+        };
+
+        // Bridge track capture overrides: RequestSent -> orange; Success -> green 1s; Timeout -> rainbow 1s
+        if state.capture_led_phase == CAPTURE_PHASE_REQUEST_SENT {
+            drop(state);
+            neopixel
+                .set_color_with_brightness(Color::Orange, neopixel_brightness)
+                .await;
+        } else if state.capture_led_phase == CAPTURE_PHASE_SUCCESS {
+            drop(state);
+            neopixel
+                .set_color_with_brightness(Color::Green, neopixel_brightness)
+                .await;
+        } else if state.capture_led_phase == CAPTURE_PHASE_TIMEOUT {
+            let deadline = state.capture_phase_deadline.unwrap_or(now);
+            let phase_start = deadline.saturating_sub(Duration::from_secs(1));
+            let elapsed = now.saturating_duration_since(phase_start);
+            let pos = ((elapsed.as_millis() % 1000) * 256 / 1000) as u8;
+            let (r, g, b) = wheel(pos);
+            drop(state);
+            neopixel
+                .set_color_with_brightness(Color::Custom(r, g, b), neopixel_brightness)
+                .await;
+        } else {
+            // Normal bridge/rev1 behaviour
+            // Determine IMU age and color
+            let color = if let Some(last_imu) = state.last_imu_timestamp {
+                let age = now.duration_since(last_imu);
+                if age.as_millis() <= 20 {
+                    Color::Green
+                } else if age.as_secs() <= 10 {
+                    Color::Blue
+                } else {
+                    Color::Red
+                }
+            } else {
+                Color::Red
+            };
+
+            // Determine GPS connection vs fix status
+            let gps_rx_recent = state
+                .last_gps_rx_timestamp
+                .map(|ts| now.duration_since(ts).as_secs() <= 3)
+                .unwrap_or(false);
+            drop(state);
+
+            if gps_fix_recent {
+                // GPS fix -> breathe (half to max brightness) for clear "alive" indication
+                let breath_period_ms: u64 = 2000;
+                let elapsed_ms = (now.as_millis() as u64) % breath_period_ms;
+                let phase_256 = (elapsed_ms * 256 / breath_period_ms) as u32;
+                let factor = if phase_256 <= 128 {
+                    128 + phase_256
+                } else {
+                    384u32.saturating_sub(phase_256)
+                };
+                let breath_brightness = (neopixel_brightness as u32 * factor / 256).min(255) as u8;
+                neopixel
+                    .set_color_with_brightness(color, breath_brightness)
+                    .await;
+            } else if gps_rx_recent {
+                // GPS connected, no fix -> fast double pulse (0.1s on, 0.1s off, 0.1s on, 0.7s off)
                 neopixel
                     .set_color_with_brightness(color, neopixel_brightness)
                     .await;
-            } else {
+                Timer::after_millis(100).await;
                 neopixel.clear().await;
+                Timer::after_millis(100).await;
+                neopixel
+                    .set_color_with_brightness(color, neopixel_brightness)
+                    .await;
+                Timer::after_millis(100).await;
+                neopixel.clear().await;
+                Timer::after_millis(700).await;
+            } else {
+                // No GPS data -> slow blink
+                slow_blink_on = !slow_blink_on;
+                if slow_blink_on {
+                    neopixel
+                        .set_color_with_brightness(color, neopixel_brightness)
+                        .await;
+                } else {
+                    neopixel.clear().await;
+                }
             }
         }
 
@@ -108,8 +171,8 @@ pub async fn start_hmi(
     }
 }
 
-/// HMI loop for floating (GPS-only) node: GREEN = GPS fix when idle; when acquiring,
-/// solid orange 50ms then rapid orange blink (50 Hz) until acquisition done.
+/// HMI loop for floating (GPS-only) node: GREEN = GPS fix when idle (breathing); when acquiring,
+/// 500ms solid orange (operator notice) then rapid orange blink until 5 samples done.
 pub async fn start_hmi_floating(
     mut user_led: Output<'static>,
     led_rate_hz: u32,
@@ -125,7 +188,9 @@ pub async fn start_hmi_floating(
     neopixel.clear().await;
     Timer::after_millis(200).await;
 
-    let period = Duration::from_hz(led_rate_hz as u64);
+    // Fast idle tick (40 Hz) so we see acquiring_gps_capture within 25 ms and get smooth breathing
+    const IDLE_TICK_MS: u64 = 25;
+    let period = Duration::from_millis(IDLE_TICK_MS);
     let mut led_on = false;
     let mut slow_blink_on = false;
 
@@ -155,18 +220,18 @@ pub async fn start_hmi_floating(
         drop(state);
 
         if acquiring {
-            // Solid orange 50 ms
+            // 500 ms solid orange so operator sees the capture request
             neopixel
                 .set_color_with_brightness(Color::Orange, neopixel_brightness)
                 .await;
-            Timer::after_millis(50).await;
-            // Rapid blink orange (50 Hz) until acquiring clears (up to ~500 ms total for 5 samples)
+            Timer::after_millis(500).await;
+            // Rapid blink orange until acquiring clears (collecting 5 samples)
             let blink_period_ms = 20u64; // 50 Hz
             let blink_start = Instant::now();
             loop {
                 let still_acquiring =
                     crate::hmi::state::HMI_STATE.0.lock().await.acquiring_gps_capture;
-                if !still_acquiring || blink_start.elapsed().as_millis() >= 600 {
+                if !still_acquiring || blink_start.elapsed().as_millis() >= 2000 {
                     break;
                 }
                 neopixel
@@ -179,10 +244,19 @@ pub async fn start_hmi_floating(
             continue;
         }
 
-        // Idle: same green GPS fix indicator as main board
+        // Idle: green GPS fix with breathe (half to max) for "alive" indication
         if gps_fix_recent {
+            let breath_period_ms: u64 = 2000;
+            let elapsed_ms = (now.as_millis() as u64) % breath_period_ms;
+            let phase_256 = (elapsed_ms * 256 / breath_period_ms) as u32;
+            let factor = if phase_256 <= 128 {
+                128 + phase_256
+            } else {
+                384u32.saturating_sub(phase_256)
+            };
+            let breath_brightness = (neopixel_brightness as u32 * factor / 256).min(255) as u8;
             neopixel
-                .set_color_with_brightness(Color::Green, neopixel_brightness)
+                .set_color_with_brightness(Color::Green, breath_brightness)
                 .await;
         } else if gps_rx_recent {
             neopixel

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -35,18 +35,24 @@ pub async fn start_hmi(
 
     let mut led_on = false;
     let mut slow_blink_on = false;
+    let led_period = Duration::from_hz(led_rate_hz as u64);
+    let mut last_led_toggle = Instant::now();
 
     loop {
         let tick_start = Instant::now();
         trace!("[HMI] - Heartbeat OK");
 
-        // Toggle user LED as heartbeat
-        if led_on {
-            user_led.set_low();
-        } else {
-            user_led.set_high();
+        // Toggle user LED at normal rate (1 Hz) even when loop is fast for breathing
+        let now_early = Instant::now();
+        if now_early.duration_since(last_led_toggle) >= led_period {
+            if led_on {
+                user_led.set_low();
+            } else {
+                user_led.set_high();
+            }
+            led_on = !led_on;
+            last_led_toggle = now_early;
         }
-        led_on = !led_on;
 
         // Read HMI state to decide NeoPixel behaviour
         let mut state = crate::hmi::state::HMI_STATE.0.lock().await;
@@ -62,7 +68,7 @@ pub async fn start_hmi(
             }
         }
 
-        // Loop period: 4x when armed; when breathing (GPS fix) use 20 Hz for smooth animation; else base rate
+        // Loop period: 4x when armed (bridge); when breathing (GPS fix) use 40 Hz for smooth animation; else base rate
         let gps_fix_recent = state.gps_fix
             && state
                 .last_gps_timestamp
@@ -123,14 +129,14 @@ pub async fn start_hmi(
             drop(state);
 
             if gps_fix_recent {
-                // GPS fix -> breathe (half to max brightness) for clear "alive" indication
+                // GPS fix -> breathe (25% to max brightness) for clear "alive" indication
                 let breath_period_ms: u64 = 2000;
                 let elapsed_ms = (now.as_millis() as u64) % breath_period_ms;
                 let phase_256 = (elapsed_ms * 256 / breath_period_ms) as u32;
                 let factor = if phase_256 <= 128 {
-                    128 + phase_256
+                    64 + (phase_256 * 192) / 128
                 } else {
-                    384u32.saturating_sub(phase_256)
+                    64 + ((256 - phase_256) * 192) / 128
                 };
                 let breath_brightness = (neopixel_brightness as u32 * factor / 256).min(255) as u8;
                 neopixel
@@ -244,15 +250,15 @@ pub async fn start_hmi_floating(
             continue;
         }
 
-        // Idle: green GPS fix with breathe (half to max) for "alive" indication
+        // Idle: green GPS fix with breathe (25% to max) for "alive" indication
         if gps_fix_recent {
             let breath_period_ms: u64 = 2000;
             let elapsed_ms = (now.as_millis() as u64) % breath_period_ms;
             let phase_256 = (elapsed_ms * 256 / breath_period_ms) as u32;
             let factor = if phase_256 <= 128 {
-                128 + phase_256
+                64 + (phase_256 * 192) / 128
             } else {
-                384u32.saturating_sub(phase_256)
+                64 + ((256 - phase_256) * 192) / 128
             };
             let breath_brightness = (neopixel_brightness as u32 * factor / 256).min(255) as u8;
             neopixel

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -106,3 +106,101 @@ pub async fn start_hmi(
         }
     }
 }
+
+/// HMI loop for floating (GPS-only) node: GREEN = GPS fix when idle; when acquiring,
+/// solid orange 50ms then rapid orange blink (50 Hz) until acquisition done.
+pub async fn start_hmi_floating(
+    mut user_led: Output<'static>,
+    led_rate_hz: u32,
+    mut neopixel: NeoPixel<'static>,
+    neopixel_brightness: u8,
+) {
+    let period = Duration::from_hz(led_rate_hz as u64);
+    let mut led_on = false;
+    let mut slow_blink_on = false;
+
+    loop {
+        let tick_start = Instant::now();
+        trace!("[HMI floating] tick");
+
+        if led_on {
+            user_led.set_low();
+        } else {
+            user_led.set_high();
+        }
+        led_on = !led_on;
+
+        let state = crate::hmi::state::HMI_STATE.0.lock().await;
+        let now = Instant::now();
+        let acquiring = state.acquiring_gps_capture;
+        let gps_fix_recent = state.gps_fix
+            && state
+                .last_gps_timestamp
+                .map(|ts| now.duration_since(ts).as_secs() <= 3)
+                .unwrap_or(false);
+        let gps_rx_recent = state
+            .last_gps_rx_timestamp
+            .map(|ts| now.duration_since(ts).as_secs() <= 3)
+            .unwrap_or(false);
+        drop(state);
+
+        if acquiring {
+            // Solid orange 50 ms
+            neopixel
+                .set_color_with_brightness(Color::Orange, neopixel_brightness)
+                .await;
+            Timer::after_millis(50).await;
+            // Rapid blink orange (50 Hz) until acquiring clears (up to ~500 ms total for 5 samples)
+            let blink_period_ms = 20u64; // 50 Hz
+            let blink_start = Instant::now();
+            loop {
+                let still_acquiring =
+                    crate::hmi::state::HMI_STATE.0.lock().await.acquiring_gps_capture;
+                if !still_acquiring || blink_start.elapsed().as_millis() >= 600 {
+                    break;
+                }
+                neopixel
+                    .set_color_with_brightness(Color::Orange, neopixel_brightness)
+                    .await;
+                Timer::after_millis(blink_period_ms / 2).await;
+                neopixel.clear().await;
+                Timer::after_millis(blink_period_ms / 2).await;
+            }
+            continue;
+        }
+
+        // Idle: same green GPS fix indicator as main board
+        if gps_fix_recent {
+            neopixel
+                .set_color_with_brightness(Color::Green, neopixel_brightness)
+                .await;
+        } else if gps_rx_recent {
+            neopixel
+                .set_color_with_brightness(Color::Green, neopixel_brightness)
+                .await;
+            Timer::after_millis(100).await;
+            neopixel.clear().await;
+            Timer::after_millis(100).await;
+            neopixel
+                .set_color_with_brightness(Color::Green, neopixel_brightness)
+                .await;
+            Timer::after_millis(100).await;
+            neopixel.clear().await;
+            Timer::after_millis(700).await;
+        } else {
+            slow_blink_on = !slow_blink_on;
+            if slow_blink_on {
+                neopixel
+                    .set_color_with_brightness(Color::Green, neopixel_brightness)
+                    .await;
+            } else {
+                neopixel.clear().await;
+            }
+        }
+
+        let elapsed = tick_start.elapsed();
+        if elapsed < period {
+            Timer::after(period - elapsed).await;
+        }
+    }
+}

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -20,6 +20,7 @@ pub async fn start_hmi(
     mut neopixel: NeoPixel<'static>,
     neopixel_brightness: u8,
 ) {
+    info!("[HMI] Task started (LED + NeoPixel, {} Hz)", led_rate_hz);
     let period = Duration::from_hz(led_rate_hz as u64);
 
     let mut led_on = false;
@@ -115,6 +116,15 @@ pub async fn start_hmi_floating(
     mut neopixel: NeoPixel<'static>,
     neopixel_brightness: u8,
 ) {
+    info!("[HMI] Floating task started (LED + NeoPixel, {} Hz)", led_rate_hz);
+    // Immediate test: flash NeoPixel at high brightness so we confirm it's driven (pin GPIO18)
+    neopixel
+        .set_color_with_brightness(Color::Green, 80)
+        .await;
+    Timer::after_millis(500).await;
+    neopixel.clear().await;
+    Timer::after_millis(200).await;
+
     let period = Duration::from_hz(led_rate_hz as u64);
     let mut led_on = false;
     let mut slow_blink_on = false;

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/mod.rs
@@ -31,8 +31,6 @@ pub async fn start_hmi(
     mut neopixel: NeoPixel<'static>,
     neopixel_brightness: u8,
 ) {
-    info!("[HMI] Task started (LED + NeoPixel, {} Hz)", led_rate_hz);
-
     let mut led_on = false;
     let mut slow_blink_on = false;
     let led_period = Duration::from_hz(led_rate_hz as u64);
@@ -185,15 +183,6 @@ pub async fn start_hmi_floating(
     mut neopixel: NeoPixel<'static>,
     neopixel_brightness: u8,
 ) {
-    info!("[HMI] Floating task started (LED + NeoPixel, {} Hz)", led_rate_hz);
-    // Immediate test: flash NeoPixel at high brightness so we confirm it's driven (pin GPIO18)
-    neopixel
-        .set_color_with_brightness(Color::Green, 80)
-        .await;
-    Timer::after_millis(500).await;
-    neopixel.clear().await;
-    Timer::after_millis(200).await;
-
     // Fast idle tick (40 Hz) so we see acquiring_gps_capture within 25 ms and get smooth breathing
     const IDLE_TICK_MS: u64 = 25;
     let period = Duration::from_millis(IDLE_TICK_MS);
@@ -250,8 +239,7 @@ pub async fn start_hmi_floating(
             continue;
         }
 
-        // Idle: green GPS fix with breathe (25% to max) for "alive" indication
-        if gps_fix_recent {
+        if gps_fix_recent { // Breathing green
             let breath_period_ms: u64 = 2000;
             let elapsed_ms = (now.as_millis() as u64) % breath_period_ms;
             let phase_256 = (elapsed_ms * 256 / breath_period_ms) as u32;
@@ -264,7 +252,7 @@ pub async fn start_hmi_floating(
             neopixel
                 .set_color_with_brightness(Color::Green, breath_brightness)
                 .await;
-        } else if gps_rx_recent {
+        } else if gps_rx_recent { // Double Blink green
             neopixel
                 .set_color_with_brightness(Color::Green, neopixel_brightness)
                 .await;
@@ -277,7 +265,7 @@ pub async fn start_hmi_floating(
             Timer::after_millis(100).await;
             neopixel.clear().await;
             Timer::after_millis(700).await;
-        } else {
+        } else { // Single Blink green
             slow_blink_on = !slow_blink_on;
             if slow_blink_on {
                 neopixel

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/neopixel.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/neopixel.rs
@@ -4,9 +4,10 @@
 //! - WS2812B Datasheet: <https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf>
 //! - esp-hal RMT examples: <https://github.com/esp-rs/esp-hal/tree/main/examples>
 
+use core::sync::atomic::{AtomicBool, Ordering};
 use esp_hal::gpio::{Level, OutputPin};
 use esp_hal::rmt::{Channel, PulseCode, Tx, TxChannelConfig, TxChannelCreator};
-use log::warn;
+use log::{info, warn};
 
 /// Simple color enum for a single NeoPixel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,6 +91,10 @@ impl<'d> NeoPixel<'d> {
     /// Async set color (non-blocking RMT transfer).
     pub async fn set_color(&mut self, color: Color) {
         self.fill_buffer(color);
+        static FIRST: AtomicBool = AtomicBool::new(true);
+        if FIRST.swap(false, Ordering::Relaxed) {
+            info!("[NeoPixel] first transmit (driver reached)");
+        }
         if let Err(e) = self.channel.transmit(&self.buffer).await {
             warn!("[NeoPixel] Transmit error: {:?}", e);
         }

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/state.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/state.rs
@@ -7,6 +7,8 @@ pub struct HmiStateData {
     pub gps_fix: bool,
     pub last_gps_timestamp: Option<Instant>,
     pub last_gps_rx_timestamp: Option<Instant>,
+    /// When true, floating node shows solid orange 50ms then rapid orange blink (acquiring GPS)
+    pub acquiring_gps_capture: bool,
 }
 
 impl Default for HmiStateData {
@@ -16,6 +18,7 @@ impl Default for HmiStateData {
             gps_fix: false,
             last_gps_timestamp: None,
             last_gps_rx_timestamp: None,
+            acquiring_gps_capture: false,
         }
     }
 }
@@ -29,6 +32,7 @@ impl HmiState {
             gps_fix: false,
             last_gps_timestamp: None,
             last_gps_rx_timestamp: None,
+            acquiring_gps_capture: false,
         }))
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/hmi/state.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/hmi/state.rs
@@ -2,6 +2,12 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_time::Instant;
 
+/// Bridge capture LED phase: 0 = Idle, 1 = RequestSent (orange), 2 = Success (blue 0.5s), 3 = Timeout (rainbow 1s)
+pub const CAPTURE_PHASE_IDLE: u8 = 0;
+pub const CAPTURE_PHASE_REQUEST_SENT: u8 = 1;
+pub const CAPTURE_PHASE_SUCCESS: u8 = 2;
+pub const CAPTURE_PHASE_TIMEOUT: u8 = 3;
+
 pub struct HmiStateData {
     pub last_imu_timestamp: Option<Instant>,
     pub gps_fix: bool,
@@ -9,6 +15,12 @@ pub struct HmiStateData {
     pub last_gps_rx_timestamp: Option<Instant>,
     /// When true, floating node shows solid orange 50ms then rapid orange blink (acquiring GPS)
     pub acquiring_gps_capture: bool,
+    /// Bridge: track capture armed (double blink rate)
+    pub track_armed: bool,
+    /// Bridge: capture LED phase (Idle / RequestSent / Success / Timeout)
+    pub capture_led_phase: u8,
+    /// When to clear Success/Timeout phase (return to Idle)
+    pub capture_phase_deadline: Option<Instant>,
 }
 
 impl Default for HmiStateData {
@@ -19,6 +31,9 @@ impl Default for HmiStateData {
             last_gps_timestamp: None,
             last_gps_rx_timestamp: None,
             acquiring_gps_capture: false,
+            track_armed: false,
+            capture_led_phase: CAPTURE_PHASE_IDLE,
+            capture_phase_deadline: None,
         }
     }
 }
@@ -33,6 +48,9 @@ impl HmiState {
             last_gps_timestamp: None,
             last_gps_rx_timestamp: None,
             acquiring_gps_capture: false,
+            track_armed: false,
+            capture_led_phase: CAPTURE_PHASE_IDLE,
+            capture_phase_deadline: None,
         }))
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/lib.rs
@@ -69,6 +69,12 @@ pub trait BoardPeripherals {
     #[cfg(feature = "gps")]
     fn take_gps2_uart(&mut self) -> Uart<'static, Async>;
 
+    /// If Some, the board provides a blocking UART for GPS baud detection (floating only). After detection, use the returned async UART.
+    #[cfg(all(feature = "gps", feature = "floating"))]
+    fn take_gps2_uart_blocking(&mut self) -> Option<Uart<'static, esp_hal::Blocking>> {
+        None
+    }
+
     // WIRELESS
     #[cfg(feature = "wifi")]
     fn take_wifi(&mut self) -> Option<WifiResources>;

--- a/sw/sensor_board/sensor_board_rev1_test/src/types.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/types.rs
@@ -19,6 +19,8 @@ pub enum CarPosition {
     RearCenter = 7,
     RearRight = 8,
     Roof = 9,
+    /// Floating (GPS-only) node for track capture
+    Floating = 254,
     /// Custom/unassigned position
     Custom = 255,
 }
@@ -37,6 +39,7 @@ impl CarPosition {
             7 => CarPosition::RearCenter,
             8 => CarPosition::RearRight,
             9 => CarPosition::Roof,
+            254 => CarPosition::Floating,
             _ => CarPosition::Custom,
         }
     }
@@ -59,6 +62,7 @@ impl CarPosition {
             CarPosition::RearCenter => "RearCenter",
             CarPosition::RearRight => "RearRight",
             CarPosition::Roof => "Roof",
+            CarPosition::Floating => "Floating",
             CarPosition::Custom => "Custom",
         }
     }
@@ -151,6 +155,10 @@ pub const fn configured_position() -> CarPosition {
     #[cfg(feature = "pos_roof")]
     {
         return CarPosition::Roof;
+    }
+    #[cfg(feature = "floating")]
+    {
+        return CarPosition::Floating;
     }
 
     // Default when no position feature is set

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/mod.rs
@@ -15,6 +15,7 @@ use nb::Error as NbError;
 pub use protocol::{
     ForwardError, MAX_USB_MESSAGE_SIZE, UsbCommand, format_mac, parse_usb_command,
     serialize_forwarded_message,
+    serialize_track_capture_heartbeat,
 };
 
 #[allow(unused_imports)]

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
@@ -118,8 +118,8 @@ pub fn serialize_forwarded_message(
             buffer[offset] = hb.magic;
             offset += 1;
         }
-        SensorPayload::TimeSync(_) => {
-            // TimeSync is not forwarded to USB host; bridge handles it internally
+        SensorPayload::TimeSync(_) | SensorPayload::RequestGpsCapture => {
+            // TimeSync and RequestGpsCapture are not forwarded to USB host
             return Err(ForwardError::UnsupportedPayload);
         }
     }
@@ -157,17 +157,21 @@ pub enum ForwardError {
 
 /// USB command type byte values (RPi -> Bridge)
 pub const CMD_TIME_SYNC: u8 = 0x01;
+/// Request floating GPS capture: bridge broadcasts RequestGpsCapture, collects 5 GPS, forwards to RPi
+pub const CMD_REQUEST_FLOATING_GPS: u8 = 0x02;
 
 /// Parsed USB command from the RPi host
 #[derive(Debug, Clone, Copy)]
 pub enum UsbCommand {
     /// TimeSync: RPi sends its session-elapsed time (microseconds)
     TimeSync { session_time_us: u64 },
+    /// Request floating GPS: broadcast to floating node, collect 5 GPS samples, forward to RPi
+    RequestFloatingGps,
 }
 
 /// Parse a COBS-decoded command buffer into a `UsbCommand`.
 ///
-/// Minimum size: 1 (command type) + 8 (payload for TimeSync) = 9 bytes.
+/// TimeSync: 1 + 8 = 9 bytes. RequestFloatingGps: 1 byte.
 pub fn parse_usb_command(buffer: &[u8]) -> Result<UsbCommand, ForwardError> {
     if buffer.is_empty() {
         return Err(ForwardError::BufferTooSmall);
@@ -181,6 +185,7 @@ pub fn parse_usb_command(buffer: &[u8]) -> Result<UsbCommand, ForwardError> {
             let session_time_us = LittleEndian::read_u64(&buffer[1..]);
             Ok(UsbCommand::TimeSync { session_time_us })
         }
+        CMD_REQUEST_FLOATING_GPS => Ok(UsbCommand::RequestFloatingGps),
         _ => Err(ForwardError::UnsupportedPayload),
     }
 }

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
@@ -21,6 +21,9 @@ pub const MAX_PAYLOAD_SIZE: usize = 64;
 /// Total maximum message size
 pub const MAX_USB_MESSAGE_SIZE: usize = HEADER_SIZE + MAX_PAYLOAD_SIZE;
 
+/// Message type byte for track-capture heartbeat (bridge -> Pi when armed). No payload.
+pub const MSG_TRACK_CAPTURE_HEARTBEAT: u8 = 0xFE;
+
 /// Serialize a forwarded sensor message for USB transmission
 ///
 /// # Arguments
@@ -118,12 +121,33 @@ pub fn serialize_forwarded_message(
             buffer[offset] = hb.magic;
             offset += 1;
         }
-        SensorPayload::TimeSync(_) | SensorPayload::RequestGpsCapture => {
-            // TimeSync and RequestGpsCapture are not forwarded to USB host
+        SensorPayload::TimeSync(_)
+        | SensorPayload::RequestGpsCapture
+        | SensorPayload::TrackCaptureArmed
+        | SensorPayload::TrackCaptureEnded => {
+            // Bridge-originated or not forwarded to USB host
             return Err(ForwardError::UnsupportedPayload);
         }
     }
 
+    Ok(offset)
+}
+
+/// Serialize a track-capture heartbeat (bridge -> Pi). Sent periodically when track capture is armed.
+/// Format: MAC(6 zeros) + NodeId(2 zeros) + Timestamp(8) + MessageType(0xFE) = 17 bytes. No payload.
+pub fn serialize_track_capture_heartbeat(timestamp_us: u64, buffer: &mut [u8]) -> Result<usize, ForwardError> {
+    if buffer.len() < HEADER_SIZE {
+        return Err(ForwardError::BufferTooSmall);
+    }
+    let mut offset = 0;
+    buffer[offset..offset + 6].copy_from_slice(&[0u8; 6]);
+    offset += 6;
+    buffer[offset..offset + 2].copy_from_slice(&[0u8; 2]);
+    offset += 2;
+    LittleEndian::write_u64(&mut buffer[offset..], timestamp_us);
+    offset += 8;
+    buffer[offset] = MSG_TRACK_CAPTURE_HEARTBEAT;
+    offset += 1;
     Ok(offset)
 }
 

--- a/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
+++ b/sw/sensor_board/sensor_board_rev1_test/src/usb/protocol.rs
@@ -159,6 +159,14 @@ pub enum ForwardError {
 pub const CMD_TIME_SYNC: u8 = 0x01;
 /// Request floating GPS capture: bridge broadcasts RequestGpsCapture, collects 5 GPS, forwards to RPi
 pub const CMD_REQUEST_FLOATING_GPS: u8 = 0x02;
+/// Arm track capture: bridge shows double blink until end
+pub const CMD_ARM_TRACK: u8 = 0x03;
+/// End track capture: bridge back to normal blink
+pub const CMD_END_TRACK: u8 = 0x04;
+/// Capture succeeded (RPi got 5 GPS): bridge shows solid blue 0.5s
+pub const CMD_CAPTURE_SUCCESS: u8 = 0x05;
+/// Capture timed out (RPi did not get 5 GPS): bridge shows rainbow 1s
+pub const CMD_CAPTURE_TIMEOUT: u8 = 0x06;
 
 /// Parsed USB command from the RPi host
 #[derive(Debug, Clone, Copy)]
@@ -167,6 +175,14 @@ pub enum UsbCommand {
     TimeSync { session_time_us: u64 },
     /// Request floating GPS: broadcast to floating node, collect 5 GPS samples, forward to RPi
     RequestFloatingGps,
+    /// Arm track capture (bridge doubles blink rate)
+    ArmTrack,
+    /// End track capture (bridge normal blink)
+    EndTrack,
+    /// Capture success (bridge shows solid blue 0.5s)
+    CaptureSuccess,
+    /// Capture timeout (bridge shows rainbow 1s)
+    CaptureTimeout,
 }
 
 /// Parse a COBS-decoded command buffer into a `UsbCommand`.
@@ -186,6 +202,10 @@ pub fn parse_usb_command(buffer: &[u8]) -> Result<UsbCommand, ForwardError> {
             Ok(UsbCommand::TimeSync { session_time_us })
         }
         CMD_REQUEST_FLOATING_GPS => Ok(UsbCommand::RequestFloatingGps),
+        CMD_ARM_TRACK => Ok(UsbCommand::ArmTrack),
+        CMD_END_TRACK => Ok(UsbCommand::EndTrack),
+        CMD_CAPTURE_SUCCESS => Ok(UsbCommand::CaptureSuccess),
+        CMD_CAPTURE_TIMEOUT => Ok(UsbCommand::CaptureTimeout),
         _ => Err(ForwardError::UnsupportedPayload),
     }
 }

--- a/sw/tools/rpi_rx_rust/Cargo.toml
+++ b/sw/tools/rpi_rx_rust/Cargo.toml
@@ -25,6 +25,10 @@ name = "rpi_rx_rust_gpio"
 path = "src/bin/rpi_rx_rust_gpio.rs"
 required-features = ["gpio"]
 
+[[bin]]
+name = "rpi_rx_rust_track_test"
+path = "src/bin/rpi_rx_rust_track_test.rs"
+
 [dependencies]
 serialport = "4.2.0"
 csv = "1.3.0"

--- a/sw/tools/rpi_rx_rust/README.md
+++ b/sw/tools/rpi_rx_rust/README.md
@@ -10,7 +10,7 @@ Raspberry Pi receiver for the sensor_board COBS-over-serial stream. Decodes IMU,
 - **Post-process AHRS**: The `ahrs_postprocess` binary runs AHRS on an existing raw log CSV (e.g. for re-runs with different parameters or when real-time AHRS was not used).
 - **Unified log layout**: Logs under `~/daq/logs/<date>/` with `<time>_raw.csv` and `<time>_postprocess.csv` (postprocess = AHRS output). Track capture CSVs under `~/daq/tracks/<date>/`.
 - **GPIO-controlled service**: The `rpi_rx_rust_gpio` binary (Linux, `--features gpio`) uses GPIOs to control logging, video recording, and track capture with no CLI, suitable for systemd.
-- **Track capture**: Request 5-sample averaged GPS from a floating sensor node; log cone/waypoint positions to CSV (GPIO or interactive `rpi_rx_rust_track_test`).
+- **Track capture**: Request 5-sample averaged GPS from a floating sensor node; log cone/waypoint positions to CSV (GPIO or interactive `rpi_rx_rust_track_test`). When armed, the Pi relies on a **track-capture heartbeat** (message type 0xFE) from the bridge every 500 ms; if no heartbeat for 3 s the Pi auto-ends track capture. If the Pi stops sending (e.g. crash), the bridge auto-ends after 2 s and other nodes resume.
 
 ## Building all binaries
 
@@ -104,12 +104,14 @@ No GPIO; all interaction is by typing commands (bridge must be on serial, defaul
 
 | Command | Action |
 |---------|--------|
-| `arm track capture` | Create a new track file and arm; next “take location” will append to it. |
+| `arm track capture` | Create a new track file and arm; bridge sends track-capture heartbeats (0xFE) every 500 ms so the Pi knows it’s alive. |
 | `take location` | Send RequestFloatingGps to bridge; receive 5 GPS samples, average, append one row (Cone #, Lat, Lon, Alt). |
-| `end track capture` | Close the current track file. |
+| `end track capture` | Close the current track file and tell the bridge to end. |
 | `quit` | Exit. |
 
-Track files are written under `~/daq/tracks/<date>/<time>.csv` (or under `RPI_RX_OUTPUT_DIR` if set). Override serial port with `RPI_RX_SERIAL_PORT` (e.g. `/dev/ttyACM0` for bridge when it’s on ACM0).
+- **Heartbeat**: Only the bridge’s **track-capture heartbeat** (type 0xFE) updates the “last activity” time. If no heartbeat for **3 s** (e.g. bridge unplugged), the Pi auto-ends track capture and closes the file.
+- **Logs**: Only messages from node `"Floating"` are printed to the console; other nodes are still received and forwarded but not logged here.
+- Track files: `~/daq/tracks/<date>/<time>.csv` (or `RPI_RX_OUTPUT_DIR`/tracks). Override serial port with `RPI_RX_SERIAL_PORT`.
 
 ### rpi_rx_rust (CLI) — no physical HMI
 

--- a/sw/tools/rpi_rx_rust/README.md
+++ b/sw/tools/rpi_rx_rust/README.md
@@ -119,7 +119,7 @@ Interaction is via command-line flags and serial/stdin; see “Usage” below.
   `cargo build --release --features gpio`
 - **Install**: Copy the binary to e.g. `/opt/rpi_rx_rust/bin/rpi_rx_rust_gpio`.
 - **Log paths**: `~/daq/logs/<date>/<time>_raw.csv` and `<time>_postprocess.csv` (when GPIO19 is high). Track files: `~/daq/tracks/<date>/<time>.csv`. Base path override: `RPI_RX_OUTPUT_DIR` (logs under `<base>/logs/<date>/`, tracks under `<base>/tracks/<date>/`).
-- **Serial port**: Default `/dev/ttyACM0` (bridge). If the bridge is on a different port (e.g. only one device on ACM1), set `RPI_RX_SERIAL_PORT`.
+- **Serial port**: Default `/dev/ttyACM0` (bridge). Which device is ACM0 vs ACM1 depends on USB enumeration order (e.g. bridge may be `/dev/ttyACM1` and sensor board `/dev/ttyACM0`). Set `RPI_RX_SERIAL_PORT` to the **bridge** port so the RPi talks to the bridge (e.g. `RPI_RX_SERIAL_PORT=/dev/ttyACM1`).
 - **Environment** (optional):
   - `RPI_RX_OUTPUT_DIR`: base directory (default `$HOME`; then `daq/logs/<date>/` and `daq/tracks/<date>/`).
   - `RPI_RX_SERIAL_PORT`: serial device for bridge (default: `/dev/ttyACM0`).

--- a/sw/tools/rpi_rx_rust/README.md
+++ b/sw/tools/rpi_rx_rust/README.md
@@ -1,6 +1,6 @@
 # rpi_rx_rust
 
-Raspberry Pi receiver for the sensor_board COBS-over-serial stream. Decodes IMU, GPS, and heartbeat messages, writes CSV logs, and optionally runs real-time AHRS (attitude/heading reference system) with synthesized GPS and velocity integration.
+Raspberry Pi receiver for the sensor_board COBS-over-serial stream. Decodes IMU, GPS, and heartbeat messages, writes CSV logs, and optionally runs real-time AHRS (attitude/heading reference system) with synthesized GPS and velocity integration. Can also request floating GPS for track capture (cone/waypoint logging).
 
 ## Features
 
@@ -8,18 +8,47 @@ Raspberry Pi receiver for the sensor_board COBS-over-serial stream. Decodes IMU,
 - **CSV logging**: Writes one row per decoded message to a raw CSV (MAC, node position/instance, timestamp, type, and type-specific fields).
 - **Real-time AHRS** (optional): Madgwick orientation filter plus velocity/position integration in NED. Uses the first IMU node as primary; first 10 seconds are treated as “at rest” for gyro bias and velocity zeroing. Outputs synthesized lat/lon/alt, vehicle heading, ground track, roll/pitch/yaw, and NED velocity at a fixed rate (default 10 Hz).
 - **Post-process AHRS**: The `ahrs_postprocess` binary runs AHRS on an existing raw log CSV (e.g. for re-runs with different parameters or when real-time AHRS was not used).
-- **Unified log layout**: All binaries write under `~/daq/logs/<date>/` with `<time>_raw.csv` and `<time>_postprocess.csv` (postprocess = AHRS output).
-- **GPIO-controlled service**: The `rpi_rx_rust_gpio` binary (Linux, `--features gpio`) uses GPIOs to control logging and video recording with no CLI flags, suitable for a systemd service that starts on boot.
+- **Unified log layout**: Logs under `~/daq/logs/<date>/` with `<time>_raw.csv` and `<time>_postprocess.csv` (postprocess = AHRS output). Track capture CSVs under `~/daq/tracks/<date>/`.
+- **GPIO-controlled service**: The `rpi_rx_rust_gpio` binary (Linux, `--features gpio`) uses GPIOs to control logging, video recording, and track capture with no CLI, suitable for systemd.
+- **Track capture**: Request 5-sample averaged GPS from a floating sensor node; log cone/waypoint positions to CSV (GPIO or interactive `rpi_rx_rust_track_test`).
+
+## Building all binaries
+
+From this directory (`sw/tools/rpi_rx_rust/`):
+
+| Binary | Build command |
+|--------|----------------|
+| `rpi_rx_rust` | `cargo build --release` |
+| `ahrs_postprocess` | `cargo build --release --bin ahrs_postprocess` |
+| `gps_extract` | `cargo build --release --bin gps_extract` |
+| `rpi_rx_rust_gpio` | `cargo build --release --features gpio` (Linux, libgpiod) |
+| `rpi_rx_rust_track_test` | `cargo build --release --bin rpi_rx_rust_track_test` |
+
+One-liner to build everything that doesn’t require optional features:
+
+```bash
+cargo build --release --bin rpi_rx_rust --bin ahrs_postprocess --bin gps_extract --bin rpi_rx_rust_track_test
+cargo build --release --features gpio  # separately, for GPIO binary (Linux)
+```
 
 ## Binaries
 
-| Binary              | Purpose |
-|---------------------|--------|
-| `rpi_rx_rust`      | Interactive/CLI: read from serial (or stdin), log raw CSV and optionally real-time AHRS. |
-| `ahrs_postprocess`  | Offline: run AHRS on a raw log CSV; output `<stem>_ahrs_postprocess.csv`. |
-| `rpi_rx_rust_gpio` | Service: GPIO-controlled start/stop; no CLI. Build with `cargo build --release --features gpio` (Linux only). |
+| Binary | Purpose |
+|--------|--------|
+| `rpi_rx_rust` | Interactive/CLI: read from serial (or stdin), log raw CSV and optionally real-time AHRS. |
+| `ahrs_postprocess` | Offline: run AHRS on a raw log CSV; output `<stem>_ahrs_postprocess.csv`. |
+| `gps_extract` | Extract or filter GPS data from logs (see binary help). |
+| `rpi_rx_rust_gpio` | Service: GPIO-controlled logging, video, and track capture; no CLI. Requires `--features gpio` (Linux). |
+| `rpi_rx_rust_track_test` | Interactive track capture: type “arm track capture”, “take location”, “end track capture” to test without GPIO. |
 
 ## Usage
+
+### Summary: how you interact with each binary
+
+- **rpi_rx_rust**: CLI flags + serial (or stdin). No GPIO.
+- **rpi_rx_rust_gpio**: GPIO only (11, 19, 26, 10, 9). No CLI; for systemd.
+- **rpi_rx_rust_track_test**: Serial + typed commands (“arm track capture”, “take location”, “end track capture”, “quit”). For testing track capture without GPIO.
+- **ahrs_postprocess** / **gps_extract**: Offline; input/output files and CLI args.
 
 ### rpi_rx_rust (CLI)
 
@@ -34,7 +63,16 @@ cargo run -- --with-ahrs
 cargo run -- --with-ahrs --ahrs-hz 50
 ```
 
-Serial defaults: `/dev/ttyACM0`, 115200 baud. If the port cannot be opened, input falls back to stdin.
+Serial defaults: `/dev/ttyACM0`, 115200 baud. If the port cannot be opened, input falls back to stdin. Set `RPI_RX_SERIAL_PORT` if the bridge is on another port.
+
+### rpi_rx_rust_track_test
+
+```bash
+cargo run --bin rpi_rx_rust_track_test
+# or: ./target/release/rpi_rx_rust_track_test
+```
+
+Then type: `arm track capture`, then `take location` for each cone/waypoint, then `end track capture` when done. Optional: `RPI_RX_SERIAL_PORT=/dev/ttyACM0` (default).
 
 ### ahrs_postprocess
 
@@ -44,23 +82,47 @@ cargo run --bin ahrs_postprocess -- --input path/to/raw.csv [--output path/to/ou
 
 Assumes the first 10 seconds of the log are at rest. Uses first GPS fix as origin. Output defaults to `<input_stem>_ahrs_postprocess.csv`.
 
-### rpi_rx_rust_gpio (service binary)
+### rpi_rx_rust_gpio (service binary) — GPIO “HMI”
 
-- **GPIO #11 (BCM 11)**: Init — start raw logging and allow AHRS to initialize (vehicle assumed level and stationary).
-- **GPIO #19 (BCM 19)**: Postprocessed — when high, also log AHRS output at the default rate (10 Hz).
-- **GPIO #26 (BCM 26)**: Video recording — when high, start video recording via camera server; when low, stop recording.
+All interaction is via GPIO; no CLI.
 
-Data logging runs while **either** GPIO #11 or #19 is high. Logs **stop only when both GPIOs are low**. Temporary loss of serial data does not stop the session; only both GPIOs going low does.
+| GPIO (BCM) | Function |
+|------------|----------|
+| **11** | Init — start raw logging; AHRS init (vehicle assumed level and stationary). |
+| **19** | Postprocessed — when high, also log AHRS at 10 Hz. |
+| **26** | Video — high = start recording, low = stop (camera server on `localhost:8888`). |
+| **10** | Track arm — **rising edge** opens a new track file under `~/daq/tracks/<date>/<time>.csv` and resets cone #. |
+| **9** | Track capture — **rising edge** (with track armed) requests floating GPS, averages 5 samples, appends one row (Cone #, Lat, Lon, Alt) and increments cone #. |
 
-Video recording is controlled independently by GPIO #26. The service communicates with a camera server running on `localhost:8888` (e.g., the `record.py` server from `/home/hardy/daq/FYDP-CV-Piside/`).
+- Data logging runs while **either** GPIO #11 or #19 is high. Logs **stop only when both are low**.
+- Video is independent of logging (GPIO #26).
+- Track capture only runs when a session is active (GPIO 11 or 19 high). Arm with GPIO 10 (high), then trigger each cone/waypoint with a rising edge on GPIO 9.
+
+### rpi_rx_rust_track_test — interactive “HMI”
+
+No GPIO; all interaction is by typing commands (bridge must be on serial, default `/dev/ttyACM0`):
+
+| Command | Action |
+|---------|--------|
+| `arm track capture` | Create a new track file and arm; next “take location” will append to it. |
+| `take location` | Send RequestFloatingGps to bridge; receive 5 GPS samples, average, append one row (Cone #, Lat, Lon, Alt). |
+| `end track capture` | Close the current track file. |
+| `quit` | Exit. |
+
+Track files are written under `~/daq/tracks/<date>/<time>.csv` (or under `RPI_RX_OUTPUT_DIR` if set). Override serial port with `RPI_RX_SERIAL_PORT` (e.g. `/dev/ttyACM0` for bridge when it’s on ACM0).
+
+### rpi_rx_rust (CLI) — no physical HMI
+
+Interaction is via command-line flags and serial/stdin; see “Usage” below.
 
 - **Build** (on Linux, with libgpiod):  
   `cargo build --release --features gpio`
 - **Install**: Copy the binary to e.g. `/opt/rpi_rx_rust/bin/rpi_rx_rust_gpio`.
-- **Log paths**: Same as CLI — `~/daq/logs/<date>/<time>_raw.csv` and `<time>_postprocess.csv` (when GPIO19 is high). Default is `$HOME/daq/logs/<date>/`; override with `RPI_RX_OUTPUT_DIR` (base path; logs go under `<RPI_RX_OUTPUT_DIR>/logs/<date>/`).
+- **Log paths**: `~/daq/logs/<date>/<time>_raw.csv` and `<time>_postprocess.csv` (when GPIO19 is high). Track files: `~/daq/tracks/<date>/<time>.csv`. Base path override: `RPI_RX_OUTPUT_DIR` (logs under `<base>/logs/<date>/`, tracks under `<base>/tracks/<date>/`).
+- **Serial port**: Default `/dev/ttyACM0` (bridge). If the bridge is on a different port (e.g. only one device on ACM1), set `RPI_RX_SERIAL_PORT`.
 - **Environment** (optional):
-  - `RPI_RX_OUTPUT_DIR`: base directory for logs (default: `$HOME`; then logs under `daq/logs/<date>/`).
-  - `RPI_RX_SERIAL_PORT`: serial device (default: `/dev/ttyACM0`).
+  - `RPI_RX_OUTPUT_DIR`: base directory (default `$HOME`; then `daq/logs/<date>/` and `daq/tracks/<date>/`).
+  - `RPI_RX_SERIAL_PORT`: serial device for bridge (default: `/dev/ttyACM0`).
 
 ## Systemd service
 

--- a/sw/tools/rpi_rx_rust/rpi-rx-rust.service
+++ b/sw/tools/rpi_rx_rust/rpi-rx-rust.service
@@ -21,7 +21,8 @@ WorkingDirectory=/opt/rpi_rx_rust
 ExecStart=/opt/rpi_rx_rust/bin/rpi_rx_rust_gpio
 
 # Logs go to ~/daq/logs/<date>/<time>_raw.csv and <time>_postprocess.csv (user's HOME when run as User=)
-# Optional: override serial port or log base directory
+# Optional: override serial port (default /dev/ttyACM0) or log base directory.
+# If bridge is on ACM0 and another board on ACM1, leave unset for ACM0.
 # Environment="RPI_RX_SERIAL_PORT=/dev/ttyACM0"
 # Environment="RPI_RX_OUTPUT_DIR=/path/to/base"   # logs under <base>/logs/<date>/
 

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
@@ -13,7 +13,7 @@ use gpiod::{Chip, EdgeDetect, Options, Bias};
 use log::*;
 use rpi_rx_rust::session::{run_session, ByteSource};
 use rpi_rx_rust::TimeSyncSender;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
@@ -24,6 +24,9 @@ use std::time::{Duration, Instant};
 const GPIO_INIT: u32 = 11;   // BCM 11: init / raw
 const GPIO_POST: u32 = 19;   // BCM 19: postprocessed logging
 const GPIO_VIDEO: u32 = 26;  // BCM 26: video recording control
+const GPIO_TRACK_ARM: u32 = 10;    // BCM 10: arm track capture (high = new track file)
+const GPIO_TRACK_CAPTURE: u32 = 9; // BCM 9: rising edge = take location (request floating GPS)
+/// Serial port for bridge. Set RPI_RX_SERIAL_PORT if bridge is not on ACM0 (e.g. bridge=ACM0, other board=ACM1).
 const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM0";
 const DEFAULT_BAUD_RATE: u32 = 115_200;
 const SERIAL_READ_TIMEOUT_MS: u64 = 200;
@@ -65,6 +68,18 @@ fn log_dir_for_today() -> PathBuf {
         Err(_) => {
             let home = std::env::var("HOME").unwrap_or_else(|_| "/opt/rpi_rx_rust".to_string());
             PathBuf::from(home).join("daq").join("logs").join(date_str)
+        }
+    }
+}
+
+/// Track directory: ~/daq/tracks/<date>. Same base as logs when RPI_RX_OUTPUT_DIR is set.
+fn track_dir_for_today() -> PathBuf {
+    let date_str = Local::now().format("%Y-%m-%d").to_string();
+    match std::env::var("RPI_RX_OUTPUT_DIR") {
+        Ok(custom) => PathBuf::from(custom).join("tracks").join(date_str),
+        Err(_) => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/opt/rpi_rx_rust".to_string());
+            PathBuf::from(home).join("daq").join("tracks").join(date_str)
         }
     }
 }
@@ -152,30 +167,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .filter_level(log::LevelFilter::Info)
         .init();
 
-    info!("rpi_rx_rust_gpio: GPIO {} (init), GPIO {} (post), GPIO {} (video); logs under ~/daq/logs/<date>/", GPIO_INIT, GPIO_POST, GPIO_VIDEO);
+    info!("rpi_rx_rust_gpio: GPIO {} (init), {} (post), {} (video), {} (track arm), {} (track capture); logs under ~/daq/logs/<date>/", GPIO_INIT, GPIO_POST, GPIO_VIDEO, GPIO_TRACK_ARM, GPIO_TRACK_CAPTURE);
 
     let chip = Chip::new("gpiochip0").or_else(|_| Chip::new(0))?;
-    let opts = Options::input([GPIO_INIT, GPIO_POST, GPIO_VIDEO])
+    let opts = Options::input([GPIO_INIT, GPIO_POST, GPIO_VIDEO, GPIO_TRACK_ARM, GPIO_TRACK_CAPTURE])
         .edge(EdgeDetect::Both)
         .bias(Bias::PullDown)
         .consumer("rpi_rx_rust_gpio");
     let mut inputs = chip.request_lines(opts)?;
-    info!("GPIO {}, {}, and {} requested (edge both, pull-down enabled)", GPIO_INIT, GPIO_POST, GPIO_VIDEO);
+    info!("GPIO {} (init), {} (post), {} (video), {} (track arm), {} (track capture) requested", GPIO_INIT, GPIO_POST, GPIO_VIDEO, GPIO_TRACK_ARM, GPIO_TRACK_CAPTURE);
 
-    let initial_values: [bool; 3] = inputs.get_values([false, false, false])?;
-    info!("Initial GPIO state: GPIO{}={}, GPIO{}={}, GPIO{}={}",
-          GPIO_INIT, initial_values[0], GPIO_POST, initial_values[1], GPIO_VIDEO, initial_values[2]);
+    let initial_values: [bool; 5] = inputs.get_values([false, false, false, false, false])?;
+    info!("Initial GPIO state: init={}, post={}, video={}, track_arm={}, track_capture={}",
+          initial_values[0], initial_values[1], initial_values[2], initial_values[3], initial_values[4]);
 
     let video_recording = Cell::new(false);
 
     loop {
         let _event = inputs.read_event()?;
-        let values: [bool; 3] = inputs.get_values([false, false, false])?;
+        let values: [bool; 5] = inputs.get_values([false, false, false, false, false])?;
         let gpio11_high = values[0];
         let gpio19_high = values[1];
         let gpio26_high = values[2];
-        info!("GPIO edge detected: GPIO{}={}, GPIO{}={}, GPIO{}={}",
-              GPIO_INIT, gpio11_high, GPIO_POST, gpio19_high, GPIO_VIDEO, gpio26_high);
+        let gpio10_high = values[3];
+        let gpio9_high = values[4];
+        info!("GPIO edge: init={}, post={}, video={}, track_arm={}, track_capture={}",
+              gpio11_high, gpio19_high, gpio26_high, gpio10_high, gpio9_high);
 
         // Handle video recording control (GPIO 26) — outside session, no timestamp yet
         if gpio26_high && !video_recording.get() {
@@ -271,20 +288,64 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         info!("Flushed serial input buffer after TimeSync propagation delay");
 
         let mut byte_source = SerialTimeoutByteSource::new(read_port);
+        let track_file: RefCell<Option<Writer<std::fs::File>>> = RefCell::new(None);
+        let cone_number = Cell::new(0u32);
+        let prev_track_arm = Cell::new(false);
+        let prev_track_capture = Cell::new(false);
+
+        let mut on_track_capture = |lat: f64, lon: f64, alt: f32| {
+            if let Some(ref mut wtr) = *track_file.borrow_mut() {
+                let n = cone_number.get();
+                if wtr.write_record([n.to_string(), lat.to_string(), lon.to_string(), alt.to_string()]).is_ok() {
+                    let _ = wtr.flush();
+                    info!("Track capture: cone #{} lat={:.6} lon={:.6} alt={:.1}", n, lat, lon, alt);
+                    cone_number.set(n + 1);
+                }
+            }
+        };
+
         let mut should_stop = || {
-            let values: [bool; 3] = match inputs.get_values([false, false, false]) {
+            let values: [bool; 5] = match inputs.get_values([false, false, false, false, false]) {
                 Ok(v) => v,
                 Err(_) => return true,
             };
             let gpio11 = values[0];
             let gpio19 = values[1];
             let gpio26 = values[2];
+            let gpio10 = values[3];
+            let gpio9 = values[4];
 
             if gpio26 && !video_recording.get() {
                 video_recording.set(start_video_recording(&session_start));
             } else if !gpio26 && video_recording.get() {
                 video_recording.set(!stop_video_recording());
             }
+
+            // Track capture: IO10 rising = new track file; IO9 rising = take location
+            if gpio10 && !prev_track_arm.get() {
+                let dir = track_dir_for_today();
+                if let Ok(()) = fs::create_dir_all(&dir) {
+                    let time_str = Local::now().format("%H-%M-%S").to_string();
+                    let path = dir.join(format!("{}.csv", time_str));
+                    if let Ok(wtr) = Writer::from_path(&path) {
+                        let mut buf = track_file.borrow_mut();
+                        *buf = Some(wtr);
+                        if let Some(ref mut w) = buf.as_mut() {
+                            let _ = w.write_record(["Cone #", "Lat", "Lon", "Alt"]);
+                            let _ = w.flush();
+                        }
+                        cone_number.set(0);
+                        info!("Track capture armed: {}", path.display());
+                    }
+                }
+            }
+            prev_track_arm.set(gpio10);
+
+            if gpio9 && !prev_track_capture.get() && track_file.borrow().is_some() {
+                timesync_sender.request_floating_gps_capture();
+                info!("Track capture: requested floating GPS (IO9 rising)");
+            }
+            prev_track_capture.set(gpio9);
 
             let active = gpio11 || gpio19;
             !active
@@ -296,6 +357,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ahrs_wtr.as_mut(),
             DEFAULT_AHRS_HZ,
             &mut should_stop,
+            Some(&timesync_sender.collecting_for_track),
+            Some(&mut on_track_capture),
         ) {
             error!("Session error: {}", e);
         }

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
@@ -321,7 +321,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 video_recording.set(!stop_video_recording());
             }
 
-            // Track capture: IO10 rising = new track file; IO9 rising = take location
+            // Track capture: IO10 rising = new track file (arm); IO10 falling = end; IO9 rising = take location
             if gpio10 && !prev_track_arm.get() {
                 let dir = track_dir_for_today();
                 if let Ok(()) = fs::create_dir_all(&dir) {
@@ -335,9 +335,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let _ = w.flush();
                         }
                         cone_number.set(0);
+                        timesync_sender.send_arm_track();
                         info!("Track capture armed: {}", path.display());
                     }
                 }
+            } else if !gpio10 && prev_track_arm.get() {
+                timesync_sender.send_end_track();
             }
             prev_track_arm.set(gpio10);
 
@@ -359,6 +362,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &mut should_stop,
             Some(&timesync_sender.collecting_for_track),
             Some(&mut on_track_capture),
+            Some(timesync_sender.pending_bridge_cmd.clone()),
+            None,
         ) {
             error!("Session error: {}", e);
         }

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_gpio.rs
@@ -364,6 +364,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(&mut on_track_capture),
             Some(timesync_sender.pending_bridge_cmd.clone()),
             None,
+            None,
         ) {
             error!("Session error: {}", e);
         }

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_track_test.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_track_test.rs
@@ -1,0 +1,180 @@
+//! Interactive track capture test: type "arm track capture", "take location", "end track capture"
+//! to test floating GPS and track CSV without GPIO. Reads from serial, writes track to ~/daq/tracks/<date>/.
+
+use chrono::Local;
+use csv::Writer;
+use log::*;
+use rpi_rx_rust::session::{run_session, ByteSource};
+use rpi_rx_rust::TimeSyncSender;
+use std::io::{self, BufRead, Read, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Default serial port (bridge). Override with RPI_RX_SERIAL_PORT (e.g. /dev/ttyACM0 for bridge, /dev/ttyACM1 if only one device).
+const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM0";
+const DEFAULT_BAUD_RATE: u32 = 115_200;
+
+fn serial_port_name() -> String {
+    std::env::var("RPI_RX_SERIAL_PORT").unwrap_or_else(|_| DEFAULT_SERIAL_PORT.to_string())
+}
+const SERIAL_READ_TIMEOUT_MS: u64 = 200;
+
+fn track_dir_for_today() -> PathBuf {
+    let date_str = Local::now().format("%Y-%m-%d").to_string();
+    match std::env::var("RPI_RX_OUTPUT_DIR") {
+        Ok(custom) => PathBuf::from(custom).join("tracks").join(date_str),
+        Err(_) => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/opt/rpi_rx_rust".to_string());
+            PathBuf::from(home).join("daq").join("tracks").join(date_str)
+        }
+    }
+}
+
+/// Byte source that reads one byte from serial with timeout; returns None on timeout.
+struct SerialTimeoutByteSource {
+    port: Box<dyn serialport::SerialPort>,
+    buf: [u8; 1],
+}
+
+impl SerialTimeoutByteSource {
+    fn new(port: Box<dyn serialport::SerialPort>) -> Self {
+        Self { port, buf: [0u8; 1] }
+    }
+}
+
+impl ByteSource for SerialTimeoutByteSource {
+    fn next_byte(&mut self) -> Option<io::Result<u8>> {
+        match self.port.read(&mut self.buf) {
+            Ok(0) => None,
+            Ok(1) => Some(Ok(self.buf[0])),
+            Ok(_) => unreachable!(),
+            Err(e) if e.kind() == io::ErrorKind::TimedOut => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    env_logger::Builder::from_default_env()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    info!("rpi_rx_rust_track_test: interactive track capture (arm / take location / end)");
+    info!("Commands: 'arm track capture' | 'take location' | 'end track capture' | 'quit'");
+
+    let port_name = serial_port_name();
+    let (read_port, write_port) = match serialport::new(&port_name, DEFAULT_BAUD_RATE)
+        .timeout(Duration::from_millis(SERIAL_READ_TIMEOUT_MS))
+        .open()
+    {
+        Ok(port) => {
+            let w = port.try_clone()?;
+            (port, w)
+        }
+        Err(e) => {
+            error!("Failed to open {}: {}", port_name, e);
+            return Err(e.into());
+        }
+    };
+
+    let session_start = Instant::now();
+    let timesync_sender = TimeSyncSender::start(write_port, session_start);
+    thread::sleep(Duration::from_millis(200));
+    if let Err(e) = read_port.clear(serialport::ClearBuffer::Input) {
+        warn!("Failed to clear serial input: {}", e);
+    }
+
+    let track_file: Arc<Mutex<Option<Writer<std::fs::File>>>> = Arc::new(Mutex::new(None));
+    let cone_number = Arc::new(AtomicU32::new(0));
+    let running = Arc::new(AtomicBool::new(true));
+    let run = running.clone();
+
+    let stdin = io::stdin();
+    let mut stdin_lock = stdin.lock();
+    let mut line = String::new();
+
+    let mut byte_source = SerialTimeoutByteSource::new(read_port);
+    let mut raw_wtr = Writer::from_writer(vec![]);
+    let run_session_stop = run.clone();
+    let collecting_for_track = timesync_sender.collecting_for_track.clone();
+
+    let tf = track_file.clone();
+    let cn = cone_number.clone();
+    let mut on_track_capture = move |lat: f64, lon: f64, alt: f32| {
+        if let Ok(mut g) = tf.lock() {
+            if let Some(ref mut wtr) = *g {
+                let n = cn.load(Ordering::Relaxed);
+                if wtr.write_record([n.to_string(), lat.to_string(), lon.to_string(), alt.to_string()]).is_ok() {
+                    let _ = wtr.flush();
+                    info!("Track: cone #{} lat={:.6} lon={:.6} alt={:.1}", n, lat, lon, alt);
+                    cn.store(n + 1, Ordering::Relaxed);
+                }
+            }
+        }
+    };
+
+    let mut ahrs_none: Option<Writer<Vec<u8>>> = None;
+    thread::spawn(move || {
+        let mut should_stop = move || !run_session_stop.load(Ordering::Relaxed);
+        let _ = run_session::<Vec<u8>, Vec<u8>, _>(
+            &mut byte_source,
+            &mut raw_wtr,
+            ahrs_none.as_mut(),
+            10,
+            &mut should_stop,
+            Some(collecting_for_track.as_ref()),
+            Some(&mut on_track_capture),
+        );
+    });
+
+    while running.load(std::sync::atomic::Ordering::Relaxed) {
+        line.clear();
+        print!("> ");
+        let _ = io::stdout().flush();
+        if stdin_lock.read_line(&mut line).is_err() || line.is_empty() {
+            continue;
+        }
+        let cmd = line.trim().to_lowercase();
+        if cmd.contains("quit") || cmd.contains("exit") {
+            running.store(false, std::sync::atomic::Ordering::Relaxed);
+            break;
+        }
+        if cmd.contains("arm") && cmd.contains("track") {
+            let dir = track_dir_for_today();
+            if std::fs::create_dir_all(&dir).is_ok() {
+                let time_str = Local::now().format("%H-%M-%S").to_string();
+                let path = dir.join(format!("{}.csv", time_str));
+                if let Ok(wtr) = Writer::from_path(&path) {
+                    if let Ok(mut buf) = track_file.lock() {
+                        *buf = Some(wtr);
+                        if let Some(ref mut w) = buf.as_mut() {
+                            let _ = w.write_record(["Cone #", "Lat", "Lon", "Alt"]);
+                            let _ = w.flush();
+                        }
+                    }
+                    cone_number.store(0, Ordering::Relaxed);
+                    info!("Track armed: {}", path.display());
+                }
+            }
+        } else if cmd.contains("take") && cmd.contains("location") {
+            if track_file.lock().map(|g| g.is_some()).unwrap_or(false) {
+                timesync_sender.request_floating_gps_capture();
+                info!("Requested floating GPS (wait for 5 samples)");
+            } else {
+                info!("Arm track capture first");
+            }
+        } else if cmd.contains("end") && cmd.contains("track") {
+            if let Ok(mut buf) = track_file.lock() {
+                *buf = None;
+            }
+            info!("Track capture ended");
+        }
+    }
+
+    timesync_sender.stop();
+    info!("Bye");
+    Ok(())
+}

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_track_test.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_track_test.rs
@@ -14,7 +14,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 /// Default serial port (bridge). Override with RPI_RX_SERIAL_PORT (e.g. /dev/ttyACM0 for bridge, /dev/ttyACM1 if only one device).
-const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM0";
+const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM1";
 const DEFAULT_BAUD_RATE: u32 = 115_200;
 
 fn serial_port_name() -> String {
@@ -101,6 +101,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let run_session_stop = run.clone();
     let collecting_for_track = timesync_sender.collecting_for_track.clone();
 
+    let bridge_pending_cmd = timesync_sender.pending_bridge_cmd.clone();
     let tf = track_file.clone();
     let cn = cone_number.clone();
     let mut on_track_capture = move |lat: f64, lon: f64, alt: f32| {
@@ -127,6 +128,8 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             &mut should_stop,
             Some(collecting_for_track.as_ref()),
             Some(&mut on_track_capture),
+            Some(bridge_pending_cmd),
+            Some("Floating"),
         );
     });
 
@@ -156,6 +159,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         }
                     }
                     cone_number.store(0, Ordering::Relaxed);
+                    timesync_sender.send_arm_track();
                     info!("Track armed: {}", path.display());
                 }
             }
@@ -170,6 +174,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             if let Ok(mut buf) = track_file.lock() {
                 *buf = None;
             }
+            timesync_sender.send_end_track();
             info!("Track capture ended");
         }
     }

--- a/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_track_test.rs
+++ b/sw/tools/rpi_rx_rust/src/bin/rpi_rx_rust_track_test.rs
@@ -8,19 +8,21 @@ use rpi_rx_rust::session::{run_session, ByteSource};
 use rpi_rx_rust::TimeSyncSender;
 use std::io::{self, BufRead, Read, Write};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Default serial port (bridge). Override with RPI_RX_SERIAL_PORT (e.g. /dev/ttyACM0 for bridge, /dev/ttyACM1 if only one device).
-const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM1";
+const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM0";
 const DEFAULT_BAUD_RATE: u32 = 115_200;
 
 fn serial_port_name() -> String {
     std::env::var("RPI_RX_SERIAL_PORT").unwrap_or_else(|_| DEFAULT_SERIAL_PORT.to_string())
 }
 const SERIAL_READ_TIMEOUT_MS: u64 = 200;
+/// No data from bridge for this long (ms) → auto-end track capture (e.g. bridge disconnected).
+const BRIDGE_SILENCE_MS: u64 = 3000;
 
 fn track_dir_for_today() -> PathBuf {
     let date_str = Local::now().format("%Y-%m-%d").to_string();
@@ -81,7 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     };
 
     let session_start = Instant::now();
-    let timesync_sender = TimeSyncSender::start(write_port, session_start);
+    let timesync_sender = Arc::new(TimeSyncSender::start(write_port, session_start));
     thread::sleep(Duration::from_millis(200));
     if let Err(e) = read_port.clear(serialport::ClearBuffer::Input) {
         warn!("Failed to clear serial input: {}", e);
@@ -91,6 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cone_number = Arc::new(AtomicU32::new(0));
     let running = Arc::new(AtomicBool::new(true));
     let run = running.clone();
+    let last_message_time_ms = Arc::new(AtomicU64::new(0));
 
     let stdin = io::stdin();
     let mut stdin_lock = stdin.lock();
@@ -102,6 +105,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let collecting_for_track = timesync_sender.collecting_for_track.clone();
 
     let bridge_pending_cmd = timesync_sender.pending_bridge_cmd.clone();
+    let last_message_ms_for_session = last_message_time_ms.clone();
     let tf = track_file.clone();
     let cn = cone_number.clone();
     let mut on_track_capture = move |lat: f64, lon: f64, alt: f32| {
@@ -130,7 +134,38 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             Some(&mut on_track_capture),
             Some(bridge_pending_cmd),
             Some("Floating"),
+            Some(last_message_ms_for_session),
         );
+    });
+
+    // Watcher: if armed and no data from bridge for 3s, auto-end track capture (e.g. bridge disconnected / Pi about to crash).
+    let watch_track_file = track_file.clone();
+    let watch_last_ms = last_message_time_ms.clone();
+    let watch_timesync = timesync_sender.clone();
+    let watch_running = running.clone();
+    let watcher_handle = thread::spawn(move || {
+        while watch_running.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_secs(1));
+            let armed = watch_track_file.lock().map(|g| g.is_some()).unwrap_or(false);
+            if !armed {
+                continue;
+            }
+            let now_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::from_secs(0))
+                .as_millis() as u64;
+            let last = watch_last_ms.load(Ordering::Relaxed);
+            if last != 0 && now_ms.saturating_sub(last) > BRIDGE_SILENCE_MS {
+                info!(
+                    "No data from bridge for {} ms, ending track capture",
+                    BRIDGE_SILENCE_MS
+                );
+                if let Ok(mut g) = watch_track_file.lock() {
+                    *g = None;
+                }
+                watch_timesync.send_end_track();
+            }
+        }
     });
 
     while running.load(std::sync::atomic::Ordering::Relaxed) {
@@ -160,6 +195,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     }
                     cone_number.store(0, Ordering::Relaxed);
                     timesync_sender.send_arm_track();
+                    // Mark that we're expecting data (watcher uses last_message_time_ms != 0)
+                    last_message_time_ms.store(
+                        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
+                        Ordering::Relaxed,
+                    );
                     info!("Track armed: {}", path.display());
                 }
             }
@@ -179,7 +219,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     }
 
-    timesync_sender.stop();
+    running.store(false, Ordering::Relaxed);
+    let _ = watcher_handle.join();
+    if let Ok(sender) = Arc::try_unwrap(timesync_sender) {
+        sender.stop();
+    }
     info!("Bye");
     Ok(())
 }

--- a/sw/tools/rpi_rx_rust/src/lib.rs
+++ b/sw/tools/rpi_rx_rust/src/lib.rs
@@ -3,9 +3,13 @@
 pub mod ahrs;
 pub mod session;
 pub mod timesync;
+pub mod track_capture;
 pub mod types;
 
 pub use ahrs::{AhrsFilter, AhrsOutputRow};
 pub use session::{run_session, ByteSource};
 pub use timesync::{encode_timesync_command, TimeSyncSender};
+pub use track_capture::{
+    encode_request_floating_gps_command, request_floating_gps, FloatingGpsResult,
+};
 pub use types::{format_mac_address, parse_message, DecodedMessage, ParserError};

--- a/sw/tools/rpi_rx_rust/src/main.rs
+++ b/sw/tools/rpi_rx_rust/src/main.rs
@@ -140,6 +140,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wtr_ahrs.as_mut(),
         args.ahrs_hz,
         &mut should_stop,
+        None,
+        None,
     )?;
 
     info!("Finished processing input. Output written to {:?}", log_file_path_raw);

--- a/sw/tools/rpi_rx_rust/src/main.rs
+++ b/sw/tools/rpi_rx_rust/src/main.rs
@@ -142,6 +142,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &mut should_stop,
         None,
         None,
+        None,
+        None,
     )?;
 
     info!("Finished processing input. Output written to {:?}", log_file_path_raw);

--- a/sw/tools/rpi_rx_rust/src/main.rs
+++ b/sw/tools/rpi_rx_rust/src/main.rs
@@ -11,12 +11,39 @@ use rpi_rx_rust::session::{run_session, ByteSource};
 
 const DEFAULT_SERIAL_PORT: &str = "/dev/ttyACM0";
 const DEFAULT_BAUD_RATE: u32 = 115_200;
+/// Serial read timeout; on timeout we return None so the session keeps polling instead of exiting.
+const SERIAL_READ_TIMEOUT_MS: u64 = 200;
 
 // =============================================================================
 // ByteSource implementations for main binary
 // =============================================================================
 
-/// Byte source from an iterator (stdin or serial without timeout); EOF yields None.
+/// Byte source from serial with timeout: returns None on timeout so the session keeps running;
+/// only real errors are propagated. Avoids exiting when the bridge is idle (e.g. no nodes in range).
+struct SerialTimeoutByteSource {
+    port: Box<dyn serialport::SerialPort>,
+    buf: [u8; 1],
+}
+
+impl SerialTimeoutByteSource {
+    fn new(port: Box<dyn serialport::SerialPort>) -> Self {
+        Self { port, buf: [0u8; 1] }
+    }
+}
+
+impl ByteSource for SerialTimeoutByteSource {
+    fn next_byte(&mut self) -> Option<io::Result<u8>> {
+        match self.port.read(&mut self.buf) {
+            Ok(0) => None,
+            Ok(1) => Some(Ok(self.buf[0])),
+            Ok(_) => unreachable!(),
+            Err(e) if e.kind() == io::ErrorKind::TimedOut => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+/// Byte source from an iterator (stdin); EOF yields None.
 struct IteratorByteSource<I>(I)
 where
     I: Iterator<Item = io::Result<u8>>;
@@ -97,23 +124,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    struct SerialAsRead(Box<dyn serialport::SerialPort>);
-    impl Read for SerialAsRead {
-        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-            self.0.as_mut().read(buf)
-        }
-    }
-
-    let mut serial_port_reader: Option<SerialAsRead> = None;
+    let mut serial_port: Option<Box<dyn serialport::SerialPort>> = None;
     let mut input_source = "stdin".to_string();
 
     match serialport::new(DEFAULT_SERIAL_PORT, DEFAULT_BAUD_RATE)
-        .timeout(Duration::from_millis(100))
+        .timeout(Duration::from_millis(SERIAL_READ_TIMEOUT_MS))
         .open()
     {
         Ok(port) => {
             info!("Successfully opened serial port: {}", DEFAULT_SERIAL_PORT);
-            serial_port_reader = Some(SerialAsRead(port));
+            serial_port = Some(port);
             input_source = format!("serial port {}", DEFAULT_SERIAL_PORT);
         }
         Err(e) => {
@@ -126,14 +146,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Reading data from {}", input_source);
 
-    let mut byte_source: Box<dyn ByteSource> = if let Some(reader) = serial_port_reader {
-        Box::new(IteratorByteSource(reader.bytes()))
+    let mut byte_source: Box<dyn ByteSource> = if let Some(port) = serial_port {
+        Box::new(SerialTimeoutByteSource::new(port))
     } else {
         Box::new(IteratorByteSource(io::stdin().bytes()))
     };
 
-    // Break when byte source returns None (EOF)
-    let mut should_stop = || true;
+    // Run until Ctrl+C (or fatal error). Session only stops when should_stop() is true.
+    let mut should_stop = || false;
     run_session(
         &mut *byte_source,
         &mut wtr,

--- a/sw/tools/rpi_rx_rust/src/main.rs
+++ b/sw/tools/rpi_rx_rust/src/main.rs
@@ -144,6 +144,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         None,
         None,
+        None,
     )?;
 
     info!("Finished processing input. Output written to {:?}", log_file_path_raw);

--- a/sw/tools/rpi_rx_rust/src/session.rs
+++ b/sw/tools/rpi_rx_rust/src/session.rs
@@ -11,7 +11,7 @@ use std::collections::VecDeque;
 use std::io;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const COBS_DECODED_BUFFER_SIZE: usize = 128;
 const AHRS_SAMPLE_PERIOD_S: f64 = 1.0 / 400.0;
@@ -32,6 +32,7 @@ pub trait ByteSource {
 /// If `bridge_pending_cmd` is `Some`, on success the session stores CMD_CAPTURE_SUCCESS for the bridge
 /// thread to send; on timeout it stores CMD_CAPTURE_TIMEOUT.
 /// If `only_log_node` is `Some("Floating")`, the per-message info! log is only emitted for that node.
+/// If `last_message_time_ms` is `Some`, it is updated with current time (ms since UNIX_EPOCH) on every parsed message (for heartbeat timeout).
 pub fn run_session<W, W2, B>(
     byte_source: &mut B,
     raw_wtr: &mut Writer<W>,
@@ -42,6 +43,7 @@ pub fn run_session<W, W2, B>(
     mut on_track_capture: Option<&mut dyn FnMut(f64, f64, f32)>,
     bridge_pending_cmd: Option<Arc<std::sync::atomic::AtomicU8>>,
     only_log_node: Option<&str>,
+    last_message_time_ms: Option<Arc<std::sync::atomic::AtomicU64>>,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     W: std::io::Write,
@@ -85,6 +87,15 @@ where
                             let raw_message = &decoded_buffer[..decoded_len];
                             match parse_message(raw_message) {
                                 Ok(msg) => {
+                                    // Only track-capture heartbeat from bridge updates heartbeat timestamp (not every message).
+                                    if msg.message_type == "TrackCaptureHeartbeat" {
+                                        if let Some(ref t) = last_message_time_ms {
+                                            let _ = SystemTime::now()
+                                                .duration_since(UNIX_EPOCH)
+                                                .map(|d| t.store(d.as_millis() as u64, Ordering::Relaxed));
+                                        }
+                                        continue; // Skip CSV/log/track capture for heartbeat
+                                    }
                                     message_count += 1;
                                     let should_log = match only_log_node {
                                         Some(node) => msg.node_position == node,

--- a/sw/tools/rpi_rx_rust/src/session.rs
+++ b/sw/tools/rpi_rx_rust/src/session.rs
@@ -2,6 +2,7 @@
 //! Optional track capture: when collecting_for_track is set, next 5 GPS are averaged and passed to callback.
 
 use crate::ahrs::AhrsFilter;
+use crate::track_capture::{CMD_CAPTURE_SUCCESS, CMD_CAPTURE_TIMEOUT};
 use crate::types::{error_decoded_message, format_mac_address, parse_message};
 use cobs::decode;
 use csv::Writer;
@@ -9,11 +10,15 @@ use log::*;
 use std::collections::VecDeque;
 use std::io;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 const COBS_DECODED_BUFFER_SIZE: usize = 128;
 const AHRS_SAMPLE_PERIOD_S: f64 = 1.0 / 400.0;
 const AHRS_BETA: f64 = 0.1;
 const TRACK_CAPTURE_NUM_GPS: usize = 5;
+/// If we don't receive 5 GPS samples within this time, we clear the capture and stop waiting.
+const TRACK_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Source of bytes (e.g. serial with timeout, or stdin). Returns `None` when no byte available (e.g. timeout).
 pub trait ByteSource {
@@ -24,6 +29,9 @@ pub trait ByteSource {
 /// Logs raw CSV to `raw_wtr`; if `ahrs_wtr` is `Some`, also runs AHRS and writes at `ahrs_hz`.
 /// If `collecting_for_track` and `on_track_capture` are both `Some`, when the flag is true the next 5 GPS
 /// messages are averaged and the callback is invoked with (lat, lon, alt).
+/// If `bridge_pending_cmd` is `Some`, on success the session stores CMD_CAPTURE_SUCCESS for the bridge
+/// thread to send; on timeout it stores CMD_CAPTURE_TIMEOUT.
+/// If `only_log_node` is `Some("Floating")`, the per-message info! log is only emitted for that node.
 pub fn run_session<W, W2, B>(
     byte_source: &mut B,
     raw_wtr: &mut Writer<W>,
@@ -32,6 +40,8 @@ pub fn run_session<W, W2, B>(
     should_stop: &mut dyn FnMut() -> bool,
     collecting_for_track: Option<&std::sync::atomic::AtomicBool>,
     mut on_track_capture: Option<&mut dyn FnMut(f64, f64, f32)>,
+    bridge_pending_cmd: Option<Arc<std::sync::atomic::AtomicU8>>,
+    only_log_node: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     W: std::io::Write,
@@ -49,6 +59,7 @@ where
 
     let mut message_count: u64 = 0;
     let mut track_gps_buf: Vec<(f64, f64, f32)> = Vec::with_capacity(TRACK_CAPTURE_NUM_GPS);
+    let mut track_capture_start: Option<Instant> = None;
 
     loop {
         let byte_opt = byte_source.next_byte();
@@ -75,46 +86,77 @@ where
                             match parse_message(raw_message) {
                                 Ok(msg) => {
                                     message_count += 1;
-                                    info!(
-                                        "[{}] Type={:?}, MAC={}, Node={}/{}, Timestamp={}us",
-                                        message_count,
-                                        msg.message_type,
-                                        format_mac_address(&msg.src_mac),
-                                        msg.node_position,
-                                        msg.node_instance,
-                                        msg.timestamp_us
-                                    );
+                                    let should_log = match only_log_node {
+                                        Some(node) => msg.node_position == node,
+                                        None => true,
+                                    };
+                                    if should_log {
+                                        info!(
+                                            "[{}] Type={:?}, MAC={}, Node={}/{}, Timestamp={}us",
+                                            message_count,
+                                            msg.message_type,
+                                            format_mac_address(&msg.src_mac),
+                                            msg.node_position,
+                                            msg.node_instance,
+                                            msg.timestamp_us
+                                        );
+                                    }
                                     raw_wtr.serialize(&msg)?;
                                     raw_wtr.flush()?;
 
-                                    // Track capture: collect 5 GPS when flag set, then average and callback
+                                    // Track capture: collect 5 GPS when flag set, then average and callback. Time out after 5s.
                                     if let (Some(collecting), Some(on_capture)) = (
                                         collecting_for_track.as_ref(),
                                         on_track_capture.as_mut(),
                                     ) {
+                                        if collecting.load(Ordering::Relaxed) && track_capture_start.is_none() {
+                                            track_capture_start = Some(Instant::now());
+                                        }
                                         if msg.message_type == "Gps"
                                             && collecting.load(Ordering::Relaxed)
                                             && msg.lat.is_some()
                                             && msg.lon.is_some()
                                             && msg.alt.is_some()
                                         {
-                                            let lat = msg.lat.unwrap();
-                                            let lon = msg.lon.unwrap();
-                                            let alt = msg.alt.unwrap();
-                                            track_gps_buf.push((lat, lon, alt));
-                                            if track_gps_buf.len() >= TRACK_CAPTURE_NUM_GPS {
-                                                let n = track_gps_buf.len();
-                                                let (slat, slon, salt) = track_gps_buf
-                                                    .drain(..)
-                                                    .fold((0.0_f64, 0.0_f64, 0.0_f32),
-                                                        |(a, b, c), (x, y, z)| (a + x, b + y, c + z));
+                                            if track_capture_start
+                                                .as_ref()
+                                                .map(|t| t.elapsed() > TRACK_CAPTURE_TIMEOUT)
+                                                .unwrap_or(false)
+                                            {
+                                                let got = track_gps_buf.len();
+                                                track_gps_buf.clear();
                                                 collecting.store(false, Ordering::Relaxed);
-                                                on_capture(
-                                                    slat / (n as f64),
-                                                    slon / (n as f64),
-                                                    salt / (n as f32),
+                                                track_capture_start = None;
+                                                if let Some(ref a) = bridge_pending_cmd {
+                                                    a.store(CMD_CAPTURE_TIMEOUT, Ordering::Relaxed);
+                                                }
+                                                warn!(
+                                                    "Track capture timed out after 5s (got {} samples), cone not recorded",
+                                                    got
                                                 );
-                                                info!("Track capture: averaged {} GPS samples", n);
+                                            } else {
+                                                let lat = msg.lat.unwrap();
+                                                let lon = msg.lon.unwrap();
+                                                let alt = msg.alt.unwrap();
+                                                track_gps_buf.push((lat, lon, alt));
+                                                if track_gps_buf.len() >= TRACK_CAPTURE_NUM_GPS {
+                                                    let n = track_gps_buf.len();
+                                                    let (slat, slon, salt) = track_gps_buf
+                                                        .drain(..)
+                                                        .fold((0.0_f64, 0.0_f64, 0.0_f32),
+                                                            |(a, b, c), (x, y, z)| (a + x, b + y, c + z));
+                                                    collecting.store(false, Ordering::Relaxed);
+                                                    track_capture_start = None;
+                                                    if let Some(ref a) = bridge_pending_cmd {
+                                                        a.store(CMD_CAPTURE_SUCCESS, Ordering::Relaxed);
+                                                    }
+                                                    on_capture(
+                                                        slat / (n as f64),
+                                                        slon / (n as f64),
+                                                        salt / (n as f32),
+                                                    );
+                                                    info!("Track capture: averaged {} GPS samples", n);
+                                                }
                                             }
                                         }
                                     }

--- a/sw/tools/rpi_rx_rust/src/session.rs
+++ b/sw/tools/rpi_rx_rust/src/session.rs
@@ -1,4 +1,5 @@
 //! Logging session: byte source abstraction and run loop (decode COBS, write CSV, optional AHRS).
+//! Optional track capture: when collecting_for_track is set, next 5 GPS are averaged and passed to callback.
 
 use crate::ahrs::AhrsFilter;
 use crate::types::{error_decoded_message, format_mac_address, parse_message};
@@ -7,10 +8,12 @@ use csv::Writer;
 use log::*;
 use std::collections::VecDeque;
 use std::io;
+use std::sync::atomic::Ordering;
 
 const COBS_DECODED_BUFFER_SIZE: usize = 128;
 const AHRS_SAMPLE_PERIOD_S: f64 = 1.0 / 400.0;
 const AHRS_BETA: f64 = 0.1;
+const TRACK_CAPTURE_NUM_GPS: usize = 5;
 
 /// Source of bytes (e.g. serial with timeout, or stdin). Returns `None` when no byte available (e.g. timeout).
 pub trait ByteSource {
@@ -19,12 +22,16 @@ pub trait ByteSource {
 
 /// Runs the decode/write loop until EOF or `should_stop()` returns true.
 /// Logs raw CSV to `raw_wtr`; if `ahrs_wtr` is `Some`, also runs AHRS and writes at `ahrs_hz`.
+/// If `collecting_for_track` and `on_track_capture` are both `Some`, when the flag is true the next 5 GPS
+/// messages are averaged and the callback is invoked with (lat, lon, alt).
 pub fn run_session<W, W2, B>(
     byte_source: &mut B,
     raw_wtr: &mut Writer<W>,
     mut ahrs_wtr: Option<&mut Writer<W2>>,
     ahrs_hz: u32,
     should_stop: &mut dyn FnMut() -> bool,
+    collecting_for_track: Option<&std::sync::atomic::AtomicBool>,
+    mut on_track_capture: Option<&mut dyn FnMut(f64, f64, f32)>,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     W: std::io::Write,
@@ -41,6 +48,7 @@ where
     let with_ahrs = ahrs_wtr.is_some();
 
     let mut message_count: u64 = 0;
+    let mut track_gps_buf: Vec<(f64, f64, f32)> = Vec::with_capacity(TRACK_CAPTURE_NUM_GPS);
 
     loop {
         let byte_opt = byte_source.next_byte();
@@ -78,6 +86,38 @@ where
                                     );
                                     raw_wtr.serialize(&msg)?;
                                     raw_wtr.flush()?;
+
+                                    // Track capture: collect 5 GPS when flag set, then average and callback
+                                    if let (Some(collecting), Some(on_capture)) = (
+                                        collecting_for_track.as_ref(),
+                                        on_track_capture.as_mut(),
+                                    ) {
+                                        if msg.message_type == "Gps"
+                                            && collecting.load(Ordering::Relaxed)
+                                            && msg.lat.is_some()
+                                            && msg.lon.is_some()
+                                            && msg.alt.is_some()
+                                        {
+                                            let lat = msg.lat.unwrap();
+                                            let lon = msg.lon.unwrap();
+                                            let alt = msg.alt.unwrap();
+                                            track_gps_buf.push((lat, lon, alt));
+                                            if track_gps_buf.len() >= TRACK_CAPTURE_NUM_GPS {
+                                                let n = track_gps_buf.len();
+                                                let (slat, slon, salt) = track_gps_buf
+                                                    .drain(..)
+                                                    .fold((0.0_f64, 0.0_f64, 0.0_f32),
+                                                        |(a, b, c), (x, y, z)| (a + x, b + y, c + z));
+                                                collecting.store(false, Ordering::Relaxed);
+                                                on_capture(
+                                                    slat / (n as f64),
+                                                    slon / (n as f64),
+                                                    salt / (n as f32),
+                                                );
+                                                info!("Track capture: averaged {} GPS samples", n);
+                                            }
+                                        }
+                                    }
 
                                     if with_ahrs {
                                         if msg.message_type == "Gps" {

--- a/sw/tools/rpi_rx_rust/src/timesync.rs
+++ b/sw/tools/rpi_rx_rust/src/timesync.rs
@@ -1,17 +1,15 @@
 //! TimeSync sender: periodically sends COBS-framed TimeSync commands to the bridge via USB serial.
-//! Can also send RequestFloatingGps when requested (for track capture).
-//!
-//! Protocol matches firmware's `parse_usb_command` in sensor_board/src/usb/protocol.rs:
-//! Raw: [CMD_TIME_SYNC=0x01][session_time_us: u64 LE] → 9 bytes, then COBS-encode + 0x00 delimiter.
+//! Can also send RequestFloatingGps when requested (for track capture) and bridge HMI commands
+//! (arm/end/success/timeout) so the bridge can drive its LED.
 
 use log::*;
 use std::io::Write;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use crate::track_capture::encode_request_floating_gps_command;
+use crate::track_capture::{encode_bridge_hmi_command, encode_request_floating_gps_command, CMD_ARM_TRACK, CMD_END_TRACK};
 
 const CMD_TIME_SYNC: u8 = 0x01;
 const TIMESYNC_INTERVAL: Duration = Duration::from_millis(500);
@@ -31,15 +29,22 @@ pub fn encode_timesync_command(session_time_us: u64) -> Vec<u8> {
     encoded
 }
 
+/// Pending bridge HMI command: 0 = none, else CMD_ARM_TRACK/CMD_END_TRACK/CMD_CAPTURE_SUCCESS/CMD_CAPTURE_TIMEOUT.
+/// Session sets success/timeout; caller sets arm/end.
+const PENDING_NONE: u8 = 0;
+
 /// Periodic TimeSync sender running on a dedicated writer thread.
 /// Optional: set request_floating_gps to true to send one RequestFloatingGps command
 /// and set collecting_for_track so the session can collect 5 GPS samples.
+/// Bridge HMI: set pending_bridge_cmd (or call send_arm_track/send_end_track) to send LED commands.
 pub struct TimeSyncSender {
     stop_flag: Arc<AtomicBool>,
     /// Set to true to request one floating GPS capture; thread sends command and sets collecting_for_track
     pub request_floating_gps: Arc<AtomicBool>,
     /// Set by thread when it sends RequestFloatingGps; session clears when 5 GPS collected
     pub collecting_for_track: Arc<AtomicBool>,
+    /// When non-zero, thread sends this 1-byte bridge HMI command (arm/end/success/timeout). Session sets success/timeout.
+    pub pending_bridge_cmd: Arc<AtomicU8>,
     handle: Option<JoinHandle<()>>,
     session_start: Instant,
 }
@@ -50,22 +55,32 @@ impl TimeSyncSender {
         let stop_flag = Arc::new(AtomicBool::new(false));
         let request_floating_gps = Arc::new(AtomicBool::new(false));
         let collecting_for_track = Arc::new(AtomicBool::new(false));
+        let pending_bridge_cmd = Arc::new(AtomicU8::new(PENDING_NONE));
         let flag = stop_flag.clone();
         let req_float = request_floating_gps.clone();
         let coll_track = collecting_for_track.clone();
+        let pending_cmd = pending_bridge_cmd.clone();
 
         let handle = thread::Builder::new()
             .name("timesync-sender".into())
             .spawn(move || {
-                info!("TimeSync sender started (interval={}ms)", TIMESYNC_INTERVAL.as_millis());
+                trace!("TimeSync sender started (interval={}ms)", TIMESYNC_INTERVAL.as_millis());
                 while !flag.load(Ordering::Relaxed) {
+                    // Send any pending bridge HMI command first (arm/end/success/timeout)
+                    let cmd_byte = pending_cmd.swap(PENDING_NONE, Ordering::Relaxed);
+                    if cmd_byte != PENDING_NONE {
+                        let frame = encode_bridge_hmi_command(cmd_byte);
+                        if let Err(e) = writer.write_all(&frame) {
+                            warn!("Bridge HMI command write error: {}", e);
+                        }
+                    }
                     if req_float.swap(false, Ordering::Relaxed) {
                         let cmd = encode_request_floating_gps_command();
                         if let Err(e) = writer.write_all(&cmd) {
                             warn!("RequestFloatingGps write error: {}", e);
                         } else {
                             coll_track.store(true, Ordering::Relaxed);
-                            info!("TimeSync thread: sent RequestFloatingGps");
+                            trace!("TimeSync thread: sent RequestFloatingGps");
                         }
                     }
                     let elapsed_us = session_start.elapsed().as_micros() as u64;
@@ -75,7 +90,7 @@ impl TimeSyncSender {
                     }
                     thread::sleep(TIMESYNC_INTERVAL);
                 }
-                info!("TimeSync sender stopped");
+                trace!("TimeSync sender stopped");
             })
             .expect("failed to spawn timesync-sender thread");
 
@@ -83,9 +98,30 @@ impl TimeSyncSender {
             stop_flag,
             request_floating_gps,
             collecting_for_track,
+            pending_bridge_cmd,
             handle: Some(handle),
             session_start,
         }
+    }
+
+    /// Tell the bridge to show "armed" (e.g. double blink). Call when user arms track capture.
+    pub fn send_arm_track(&self) {
+        self.pending_bridge_cmd.store(CMD_ARM_TRACK, Ordering::Relaxed);
+    }
+
+    /// Tell the bridge to show "not armed". Call when user ends track capture.
+    pub fn send_end_track(&self) {
+        self.pending_bridge_cmd.store(CMD_END_TRACK, Ordering::Relaxed);
+    }
+
+    /// Tell the bridge capture succeeded (session sets this when 5 GPS received).
+    pub fn send_capture_success(&self) {
+        self.pending_bridge_cmd.store(crate::track_capture::CMD_CAPTURE_SUCCESS, Ordering::Relaxed);
+    }
+
+    /// Tell the bridge capture timed out (session sets this on 5s timeout).
+    pub fn send_capture_timeout(&self) {
+        self.pending_bridge_cmd.store(crate::track_capture::CMD_CAPTURE_TIMEOUT, Ordering::Relaxed);
     }
 
     /// Request one floating GPS capture (bridge will return 5 samples; session collects them).

--- a/sw/tools/rpi_rx_rust/src/timesync.rs
+++ b/sw/tools/rpi_rx_rust/src/timesync.rs
@@ -1,4 +1,5 @@
 //! TimeSync sender: periodically sends COBS-framed TimeSync commands to the bridge via USB serial.
+//! Can also send RequestFloatingGps when requested (for track capture).
 //!
 //! Protocol matches firmware's `parse_usb_command` in sensor_board/src/usb/protocol.rs:
 //! Raw: [CMD_TIME_SYNC=0x01][session_time_us: u64 LE] → 9 bytes, then COBS-encode + 0x00 delimiter.
@@ -9,6 +10,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
+
+use crate::track_capture::encode_request_floating_gps_command;
 
 const CMD_TIME_SYNC: u8 = 0x01;
 const TIMESYNC_INTERVAL: Duration = Duration::from_millis(500);
@@ -29,8 +32,14 @@ pub fn encode_timesync_command(session_time_us: u64) -> Vec<u8> {
 }
 
 /// Periodic TimeSync sender running on a dedicated writer thread.
+/// Optional: set request_floating_gps to true to send one RequestFloatingGps command
+/// and set collecting_for_track so the session can collect 5 GPS samples.
 pub struct TimeSyncSender {
     stop_flag: Arc<AtomicBool>,
+    /// Set to true to request one floating GPS capture; thread sends command and sets collecting_for_track
+    pub request_floating_gps: Arc<AtomicBool>,
+    /// Set by thread when it sends RequestFloatingGps; session clears when 5 GPS collected
+    pub collecting_for_track: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
     session_start: Instant,
 }
@@ -39,13 +48,26 @@ impl TimeSyncSender {
     /// Spawn the sender thread. Begins sending immediately.
     pub fn start(mut writer: Box<dyn serialport::SerialPort>, session_start: Instant) -> Self {
         let stop_flag = Arc::new(AtomicBool::new(false));
+        let request_floating_gps = Arc::new(AtomicBool::new(false));
+        let collecting_for_track = Arc::new(AtomicBool::new(false));
         let flag = stop_flag.clone();
+        let req_float = request_floating_gps.clone();
+        let coll_track = collecting_for_track.clone();
 
         let handle = thread::Builder::new()
             .name("timesync-sender".into())
             .spawn(move || {
                 info!("TimeSync sender started (interval={}ms)", TIMESYNC_INTERVAL.as_millis());
                 while !flag.load(Ordering::Relaxed) {
+                    if req_float.swap(false, Ordering::Relaxed) {
+                        let cmd = encode_request_floating_gps_command();
+                        if let Err(e) = writer.write_all(&cmd) {
+                            warn!("RequestFloatingGps write error: {}", e);
+                        } else {
+                            coll_track.store(true, Ordering::Relaxed);
+                            info!("TimeSync thread: sent RequestFloatingGps");
+                        }
+                    }
                     let elapsed_us = session_start.elapsed().as_micros() as u64;
                     let frame = encode_timesync_command(elapsed_us);
                     if let Err(e) = writer.write_all(&frame) {
@@ -59,9 +81,16 @@ impl TimeSyncSender {
 
         Self {
             stop_flag,
+            request_floating_gps,
+            collecting_for_track,
             handle: Some(handle),
             session_start,
         }
+    }
+
+    /// Request one floating GPS capture (bridge will return 5 samples; session collects them).
+    pub fn request_floating_gps_capture(&self) {
+        self.request_floating_gps.store(true, Ordering::Relaxed);
     }
 
     /// Signal the thread to stop and join it.

--- a/sw/tools/rpi_rx_rust/src/track_capture.rs
+++ b/sw/tools/rpi_rx_rust/src/track_capture.rs
@@ -1,0 +1,130 @@
+//! Track capture: request floating GPS from bridge, average 5 samples, write to CSV.
+//!
+//! Protocol: RPi sends CMD_REQUEST_FLOATING_GPS (0x02) COBS-framed; bridge broadcasts
+//! RequestGpsCapture, collects 5 GPS from floating node, forwards as 5 normal GPS frames to RPi.
+
+use cobs::decode;
+use log::*;
+use std::collections::VecDeque;
+use std::io::Write;
+
+use crate::types::parse_message;
+
+const CMD_REQUEST_FLOATING_GPS: u8 = 0x02;
+const COBS_DECODED_BUFFER_SIZE: usize = 128;
+const NUM_GPS_SAMPLES: usize = 5;
+
+/// Encode and return COBS-framed RequestFloatingGps command (1 byte payload + delimiter).
+pub fn encode_request_floating_gps_command() -> Vec<u8> {
+    let raw = [CMD_REQUEST_FLOATING_GPS];
+    let max_encoded = cobs::max_encoding_length(1);
+    let mut encoded = vec![0u8; max_encoded + 1];
+    let n = cobs::encode(&raw, &mut encoded);
+    encoded.truncate(n + 1);
+    encoded[n] = 0x00;
+    encoded
+}
+
+/// Result of one floating GPS capture: averaged position (and optional debug fields).
+#[derive(Debug, Clone)]
+pub struct FloatingGpsResult {
+    pub lat: f64,
+    pub lon: f64,
+    pub alt: f32,
+    pub num_samples: usize,
+    pub hdop: Option<f32>,
+    pub num_sats: Option<u32>,
+}
+
+/// Request floating GPS from bridge and read 5 GPS frames from the byte stream.
+/// Caller must provide the next byte from the same serial stream (e.g. the session's byte source)
+/// and a writer to send the command. Returns averaged lat/lon/alt or error.
+///
+/// This consumes bytes from the stream until 5 GPS messages are received or timeout.
+pub fn request_floating_gps<B, W>(
+    byte_source: &mut B,
+    writer: &mut W,
+    timeout_ms: u64,
+) -> Result<FloatingGpsResult, Box<dyn std::error::Error + Send + Sync>>
+where
+    B: crate::session::ByteSource,
+    W: Write,
+{
+    let cmd = encode_request_floating_gps_command();
+    writer.write_all(&cmd)?;
+    writer.flush()?;
+    info!("Track capture: sent RequestFloatingGps, waiting for 5 GPS samples");
+
+    let mut cobs_buf: VecDeque<u8> = VecDeque::new();
+    let mut decoded_buf = [0u8; COBS_DECODED_BUFFER_SIZE];
+    let mut samples: Vec<(f64, f64, f32)> = Vec::with_capacity(NUM_GPS_SAMPLES);
+    let start = std::time::Instant::now();
+
+    while samples.len() < NUM_GPS_SAMPLES && start.elapsed().as_millis() < timeout_ms as u128 {
+        let byte_opt = byte_source.next_byte();
+        let byte = match byte_opt {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => return Err(e.into()),
+            None => continue,
+        };
+
+        cobs_buf.push_back(byte);
+        if byte != 0x00 {
+            continue;
+        }
+
+        let frame: Vec<u8> = cobs_buf.drain(..).collect();
+        let to_decode = if frame.last() == Some(&0x00) {
+            &frame[..frame.len().saturating_sub(1)]
+        } else {
+            &frame[..]
+        };
+        if to_decode.is_empty() {
+            continue;
+        }
+
+        match decode(to_decode, &mut decoded_buf) {
+            Ok(decoded_len) => {
+                let raw = &decoded_buf[..decoded_len];
+                match parse_message(raw) {
+                    Ok(msg) => {
+                        if msg.message_type == "Gps" {
+                            if let (Some(lat), Some(lon), Some(alt)) =
+                                (msg.lat, msg.lon, msg.alt)
+                            {
+                                samples.push((lat, lon, alt));
+                                info!(
+                                    "Track capture: GPS sample {}/{} lat={:.6} lon={:.6}",
+                                    samples.len(),
+                                    NUM_GPS_SAMPLES,
+                                    lat,
+                                    lon
+                                );
+                            }
+                        }
+                    }
+                    Err(_) => {}
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    if samples.is_empty() {
+        return Err("No GPS samples received within timeout".into());
+    }
+
+    let n = samples.len();
+    let (sum_lat, sum_lon, sum_alt) = samples.into_iter().fold(
+        (0.0_f64, 0.0_f64, 0.0_f32),
+        |(slat, slon, salt), (lat, lon, alt)| (slat + lat, slon + lon, salt + alt),
+    );
+    Ok(FloatingGpsResult {
+        lat: sum_lat / (n as f64),
+        lon: sum_lon / (n as f64),
+        alt: sum_alt / (n as f32),
+        num_samples: n,
+        hdop: None,
+        num_sats: None,
+    })
+}

--- a/sw/tools/rpi_rx_rust/src/track_capture.rs
+++ b/sw/tools/rpi_rx_rust/src/track_capture.rs
@@ -14,6 +14,23 @@ const CMD_REQUEST_FLOATING_GPS: u8 = 0x02;
 const COBS_DECODED_BUFFER_SIZE: usize = 128;
 const NUM_GPS_SAMPLES: usize = 5;
 
+/// Bridge HMI commands (RPi -> Bridge over USB). Same values as bridge firmware CMD_*.
+pub const CMD_ARM_TRACK: u8 = 0x03;
+pub const CMD_END_TRACK: u8 = 0x04;
+pub const CMD_CAPTURE_SUCCESS: u8 = 0x05;
+pub const CMD_CAPTURE_TIMEOUT: u8 = 0x06;
+
+/// Encode and return COBS-framed 1-byte bridge HMI command (e.g. arm/end/success/timeout).
+pub fn encode_bridge_hmi_command(cmd: u8) -> Vec<u8> {
+    let raw = [cmd];
+    let max_encoded = cobs::max_encoding_length(1);
+    let mut encoded = vec![0u8; max_encoded + 1];
+    let n = cobs::encode(&raw, &mut encoded);
+    encoded.truncate(n + 1);
+    encoded[n] = 0x00;
+    encoded
+}
+
 /// Encode and return COBS-framed RequestFloatingGps command (1 byte payload + delimiter).
 pub fn encode_request_floating_gps_command() -> Vec<u8> {
     let raw = [CMD_REQUEST_FLOATING_GPS];

--- a/sw/tools/rpi_rx_rust/src/types.rs
+++ b/sw/tools/rpi_rx_rust/src/types.rs
@@ -77,6 +77,8 @@ impl NodeId {
 pub enum MessageType {
     Imu = 0x01,
     Gps = 0x02,
+    /// Bridge sends this to Pi when track capture is armed (heartbeat so Pi can detect bridge alive).
+    TrackCaptureHeartbeat = 0xFE,
     Heartbeat = 0xFF,
     Unknown = 0x00,
 }
@@ -86,6 +88,7 @@ impl MessageType {
         match value {
             0x01 => MessageType::Imu,
             0x02 => MessageType::Gps,
+            0xFE => MessageType::TrackCaptureHeartbeat,
             0xFF => MessageType::Heartbeat,
             _ => MessageType::Unknown,
         }
@@ -272,6 +275,9 @@ pub fn parse_message(buffer: &[u8]) -> Result<DecodedMessage, ParserError> {
             }
             let mut payload_reader = io::Cursor::new(payload_data);
             decoded_msg.magic = Some(payload_reader.read_u8()?);
+        }
+        MessageType::TrackCaptureHeartbeat => {
+            // No payload; bridge sends this when track capture is armed so Pi can treat it as heartbeat.
         }
         MessageType::Unknown => {
             return Err(ParserError::InvalidMessageType(msg_type_byte));

--- a/sw/tools/rpi_rx_rust/src/types.rs
+++ b/sw/tools/rpi_rx_rust/src/types.rs
@@ -17,6 +17,7 @@ pub enum CarPosition {
     RearCenter = 7,
     RearRight = 8,
     Roof = 9,
+    Floating = 254,
     Custom = 255,
 }
 
@@ -33,6 +34,7 @@ impl CarPosition {
             7 => CarPosition::RearCenter,
             8 => CarPosition::RearRight,
             9 => CarPosition::Roof,
+            254 => CarPosition::Floating,
             _ => CarPosition::Custom,
         }
     }
@@ -49,6 +51,7 @@ impl CarPosition {
             CarPosition::RearCenter => "RearCenter",
             CarPosition::RearRight => "RearRight",
             CarPosition::Roof => "Roof",
+            CarPosition::Floating => "Floating",
             CarPosition::Custom => "Custom",
         }
     }


### PR DESCRIPTION
# Overview

This PR brings a feature we call "track capture" (GPS Cone location capture), which allows for a specially designated "floating" sensor node to report GPS locations of cones or key features on the track. This gets saved to a CSV file which the replay system can then ingest in order to re-create the map.

Key changes were made to:
- Aircomm protocol
- Bridge board functionality
- RPi Rust Receive functionality

## RPi Functionality
- Switch 2 (IO10) used to Arm system
- Switch 3 (IO9) used to toggle a capture
- Heartbeats exchanged between Pi and Bridge to ensure consistent comms
- Requests sent from Pi through bridge, Responses sent from bridge to Pi

## Bridge functionality
- HMI now does something (see readme)
- Passes requests/responses from Pi to Sensor Nodes (including stoppage of other nodes when armed)
- Added UART debug logging option 

## Aircomm Changes
- Added new message types
- Added bi-directional communication
- Allows bridge board to request sensor boards to pause transmission (when track capture is armed)

# Testing
https://youtu.be/JFtCyzPrSQI
Doesn't break existing functionality:
<img width="2544" height="1366" alt="image" src="https://github.com/user-attachments/assets/a7ac1551-2f4b-4879-b8bd-a5a59d44bdfa" />
